### PR TITLE
Use separate proxy settings for Maven repository when enabled

### DIFF
--- a/dynamic/mvn-settings.xml.tmpl
+++ b/dynamic/mvn-settings.xml.tmpl
@@ -32,22 +32,22 @@
        uncomment the proxies section and insert proxy details. -->
   <!-- https://maven.apache.org/guides/mini/guide-proxies.html -->
 
-{{if (getenv "INSTANA_AGENT_PROXY_HOST") not eq "" }}
+{{if (getenv "INSTANA_REPOSITORY_PROXY_HOST") not eq "" }}
   <proxies>
     <proxy>
       <active>true</active>
-      <host>{{ getenv "INSTANA_AGENT_PROXY_HOST" }}</host>
-  {{ if (getenv "INSTANA_AGENT_PROXY_PORT") not eq "" }}
-      <port>{{ getenv "INSTANA_AGENT_PROXY_PORT" }}</port>
+      <host>{{ getenv "INSTANA_REPOSITORY_PROXY_HOST" }}</host>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_PORT") not eq "" }}
+      <port>{{ getenv "INSTANA_REPOSITORY_PROXY_PORT" }}</port>
   {{end}}
-  {{ if (getenv "INSTANA_AGENT_PROXY_USER") not eq "" }}
-      <username>{{ getenv "INSTANA_AGENT_PROXY_USER" }}</username>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_USER") not eq "" }}
+      <username>{{ getenv "INSTANA_REPOSITORY_PROXY_USER" }}</username>
   {{end}}
-  {{ if (getenv "INSTANA_AGENT_PROXY_PROTOCOL") not eq "" }}
-      <protocol>{{ getenv "INSTANA_AGENT_PROXY_PROTOCOL" }}</protocol>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_PROTOCOL") not eq "" }}
+      <protocol>{{ getenv "INSTANA_REPOSITORY_PROXY_PROTOCOL" }}</protocol>
   {{end}}
-  {{ if (getenv "INSTANA_AGENT_PROXY_PASSWORD") not eq "" }}
-      <password>{{ getenv "INSTANA_AGENT_PROXY_PASSWORD" }}</password>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_PASSWORD") not eq "" }}
+      <password>{{ getenv "INSTANA_REPOSITORY_PROXY_PASSWORD" }}</password>
   {{end}}
     </proxy>
   </proxies>

--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -45,6 +45,21 @@ if [ -z "${INSTANA_DOWNLOAD_KEY}" ]; then
   INSTANA_DOWNLOAD_KEY="${INSTANA_AGENT_KEY}"
 fi
 
+# Take over Agent Proxy variables if no Repository Proxy is enabled
+case ${INSTANA_REPOSITORY_PROXY_ENABLED} in
+  y|Y|yes|Yes|YES|1|true)
+	# Don't do anything, use existing variables
+	;;
+  *)
+	INSTANA_REPOSITORY_PROXY_HOST=${INSTANA_AGENT_PROXY_HOST}
+	INSTANA_REPOSITORY_PROXY_PORT=${INSTANA_AGENT_PROXY_PORT}
+	INSTANA_REPOSITORY_PROXY_PROTOCOL=${INSTANA_AGENT_PROXY_PROTOCOL}
+	INSTANA_REPOSITORY_PROXY_USER=${INSTANA_AGENT_PROXY_USER}
+	INSTANA_REPOSITORY_PROXY_PASSWORD=${INSTANA_AGENT_PROXY_PASSWORD}
+	INSTANA_REPOSITORY_PROXY_USE_DNS=${INSTANA_AGENT_PROXY_USE_DNS}
+	;;
+esac
+
 rm -rf /tmp/* /opt/instana/agent/etc/org.ops4j.pax.logging.cfg \
   /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg  \
   /opt/instana/agent/etc/instana/configuration.yaml \

--- a/rhel/mvn-settings.xml.tmpl
+++ b/rhel/mvn-settings.xml.tmpl
@@ -32,22 +32,22 @@
        uncomment the proxies section and insert proxy details. -->
   <!-- https://maven.apache.org/guides/mini/guide-proxies.html -->
 
-{{if (getenv "INSTANA_AGENT_PROXY_HOST") not eq "" }}
+{{if (getenv "INSTANA_REPOSITORY_PROXY_HOST") not eq "" }}
   <proxies>
     <proxy>
       <active>true</active>
-      <host>{{ getenv "INSTANA_AGENT_PROXY_HOST" }}</host>
-  {{ if (getenv "INSTANA_AGENT_PROXY_PORT") not eq "" }}
-      <port>{{ getenv "INSTANA_AGENT_PROXY_PORT" }}</port>
+      <host>{{ getenv "INSTANA_REPOSITORY_PROXY_HOST" }}</host>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_PORT") not eq "" }}
+      <port>{{ getenv "INSTANA_REPOSITORY_PROXY_PORT" }}</port>
   {{end}}
-  {{ if (getenv "INSTANA_AGENT_PROXY_USER") not eq "" }}
-      <username>{{ getenv "INSTANA_AGENT_PROXY_USER" }}</username>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_USER") not eq "" }}
+      <username>{{ getenv "INSTANA_REPOSITORY_PROXY_USER" }}</username>
   {{end}}
-  {{ if (getenv "INSTANA_AGENT_PROXY_PROTOCOL") not eq "" }}
-      <protocol>{{ getenv "INSTANA_AGENT_PROXY_PROTOCOL" }}</protocol>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_PROTOCOL") not eq "" }}
+      <protocol>{{ getenv "INSTANA_REPOSITORY_PROXY_PROTOCOL" }}</protocol>
   {{end}}
-  {{ if (getenv "INSTANA_AGENT_PROXY_PASSWORD") not eq "" }}
-      <password>{{ getenv "INSTANA_AGENT_PROXY_PASSWORD" }}</password>
+  {{ if (getenv "INSTANA_REPOSITORY_PROXY_PASSWORD") not eq "" }}
+      <password>{{ getenv "INSTANA_REPOSITORY_PROXY_PASSWORD" }}</password>
   {{end}}
     </proxy>
   </proxies>

--- a/rhel/run.sh
+++ b/rhel/run.sh
@@ -45,6 +45,21 @@ if [ -z "${INSTANA_DOWNLOAD_KEY}" ]; then
   INSTANA_DOWNLOAD_KEY="${INSTANA_AGENT_KEY}"
 fi
 
+# Take over Agent Proxy variables if no Repository Proxy is enabled
+case ${INSTANA_REPOSITORY_PROXY_ENABLED} in
+  y|Y|yes|Yes|YES|1|true)
+	# Don't do anything, use existing variables
+	;;
+  *)
+	INSTANA_REPOSITORY_PROXY_HOST=${INSTANA_AGENT_PROXY_HOST}
+	INSTANA_REPOSITORY_PROXY_PORT=${INSTANA_AGENT_PROXY_PORT}
+	INSTANA_REPOSITORY_PROXY_PROTOCOL=${INSTANA_AGENT_PROXY_PROTOCOL}
+	INSTANA_REPOSITORY_PROXY_USER=${INSTANA_AGENT_PROXY_USER}
+	INSTANA_REPOSITORY_PROXY_PASSWORD=${INSTANA_AGENT_PROXY_PASSWORD}
+	INSTANA_REPOSITORY_PROXY_USE_DNS=${INSTANA_AGENT_PROXY_USE_DNS}
+	;;
+esac
+
 rm -rf /tmp/* /opt/instana/agent/etc/org.ops4j.pax.logging.cfg \
   /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg  \
   /opt/instana/agent/etc/instana/configuration.yaml \


### PR DESCRIPTION
Replacing PR https://github.com/instana/instana-agent-docker/pull/14 to correctly introduce and use the Maven proxy variables.

Need to be enabled explicitly, as otherwise it will use the 'default' Agent proxy settings.