### PR TITLE
Add initial version of crashReport script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node {
       }
     }
   }
-  
+
   cleanUp()
   slackSend channel: "#${SLACK_CHANNEL}", color: "#389a07", message: "Successfully build Instana agent docker ${INSTANA_AGENT_RELEASE} \n(<${env.BUILD_URL}|Open>)"
 }
@@ -85,6 +85,7 @@ node {
 def buildImage(name, context) {
   try {
     sh """
+      cp -r ./util ./${context}/ \
       docker build ./${context} --build-arg FTP_PROXY=${INSTANA_AGENT_KEY} --no-cache -t ${name}:${INSTANA_AGENT_RELEASE}
     """
   } catch(e) {
@@ -118,14 +119,14 @@ def publishImage(sourceName, targetName) {
     """
     cleanUp()
     throw e;
-  } 
+  }
 }
 
 def cleanUp() {
   println "Cleaning up docker images"
   sh '''
     images=$(docker images --format='{{.Repository}} {{.ID}}' | grep -E '.*instana.*agent.*' | cut -d ' ' -f 2 | uniq)
-    if [[ ! -z "${images}" ]]; then 
+    if [[ ! -z "${images}" ]]; then
       docker rmi --force ${images}
     fi
   '''

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -47,6 +47,7 @@ ADD com.instana.agent.main.sender.Backend.cfg.tmpl /root/
 ADD com.instana.agent.main.config.UpdateManager.cfg.tmpl /root/
 ADD com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl /root/
 ADD mvn-settings.xml.tmpl /root/
+ADD util /root/
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/dynamic/org.ops4j.pax.logging.cfg
+++ b/dynamic/org.ops4j.pax.logging.cfg
@@ -1,5 +1,5 @@
 ################################################################################
-#    
+#
 #    Config file shipped by Apache Karaf under ASF license modified by Instana.
 #
 ################################################################################
@@ -30,7 +30,7 @@ log4j2.logger.instana.level = INFO
 
 # Root logger - Only change on request by support.
 log4j2.rootLogger.level = ERROR
-#log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
+log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
 log4j2.rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
 log4j2.rootLogger.appenderRef.Console.ref = Console
 #log4j2.rootLogger.appenderRef.Syslog.ref = Syslog
@@ -57,7 +57,9 @@ log4j2.appender.rolling.layout.type = PatternLayout
 log4j2.appender.rolling.layout.pattern = ${log4j2.pattern}
 log4j2.appender.rolling.policies.type = Policies
 log4j2.appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-log4j2.appender.rolling.policies.size.size = 2MB
+log4j2.appender.rolling.policies.size.size = 250KB
+log4j2.appender.rolling.strategy.type = DefaultRolloverStrategy
+log4j2.appender.rolling.strategy.max = 2
 
 # OSGi appender
 log4j2.appender.osgi.type = PaxOsgi

--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -118,5 +118,21 @@ if [ -d /host/proc ]; then
   export INSTANA_AGENT_PROC_PATH=/host/proc
 fi
 
+if [ -f /root/crashReport.sh ]; then
+  cp /root/crashReport.sh /opt/instana/agent/crashReport.sh
+
+  # Rewrite the Karaf script to make sure spaces in JAVA_OPTS are properly escaped (JAVA_OPTS is not within quotes)
+  sed -i "s|\ \${JAVA_OPTS}\ |\ \"\${JAVA_OPTS}\"\ |g" /opt/instana/agent/bin/karaf
+
+  FLAGS="-XX:OnError=\"/opt/instana/agent/crashReport.sh %p\" -XX:ErrorFile=/opt/instana/agent/hs_err.log -XX:OnOutOfMemoryError=\"/opt/instana/agent/crashReport.sh %p 'Out of Memory'\""
+  # Ensure to check if JAVA_OPTS are already configured, just including possibly existing JAVA_OPTS might introduce
+  # spaces when no options are set, which the Java command can't handle
+  if [ "x${JAVA_OPTS}" = "x" ]; then
+	export JAVA_OPTS="${FLAGS}"
+  else
+	export JAVA_OPTS="${JAVA_OPTS} ${FLAGS}"
+  fi
+fi
+
 echo "Starting Instana Agent ..."
 exec /opt/instana/agent/bin/karaf daemon

--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -130,7 +130,7 @@ if [ -f /root/crashReport.sh ]; then
   if [ "x${JAVA_OPTS}" = "x" ]; then
 	export JAVA_OPTS="${FLAGS}"
   else
-	export JAVA_OPTS="${JAVA_OPTS} ${FLAGS}"
+	export JAVA_OPTS="${FLAGS} ${JAVA_OPTS}"
   fi
 fi
 

--- a/dynamic/util/.gitignore
+++ b/dynamic/util/.gitignore
@@ -1,0 +1,1 @@
+crashReport.sh

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -52,6 +52,7 @@ ADD com.instana.agent.main.sender.Backend.cfg.tmpl /root/
 ADD com.instana.agent.main.config.UpdateManager.cfg.tmpl /root/
 ADD com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl /root/
 ADD mvn-settings.xml.tmpl /root/
+ADD util /root/
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/rhel/org.ops4j.pax.logging.cfg
+++ b/rhel/org.ops4j.pax.logging.cfg
@@ -1,5 +1,5 @@
 ################################################################################
-#    
+#
 #    Config file shipped by Apache Karaf under ASF license modified by Instana.
 #
 ################################################################################
@@ -30,7 +30,7 @@ log4j2.logger.instana.level = INFO
 
 # Root logger - Only change on request by support.
 log4j2.rootLogger.level = ERROR
-#log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
+log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
 log4j2.rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
 log4j2.rootLogger.appenderRef.Console.ref = Console
 #log4j2.rootLogger.appenderRef.Syslog.ref = Syslog
@@ -57,7 +57,9 @@ log4j2.appender.rolling.layout.type = PatternLayout
 log4j2.appender.rolling.layout.pattern = ${log4j2.pattern}
 log4j2.appender.rolling.policies.type = Policies
 log4j2.appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-log4j2.appender.rolling.policies.size.size = 2MB
+log4j2.appender.rolling.policies.size.size = 250KB
+log4j2.appender.rolling.strategy.type = DefaultRolloverStrategy
+log4j2.appender.rolling.strategy.max = 2
 
 # OSGi appender
 log4j2.appender.osgi.type = PaxOsgi

--- a/rhel/run.sh
+++ b/rhel/run.sh
@@ -118,5 +118,21 @@ if [ -d /host/proc ]; then
   export INSTANA_AGENT_PROC_PATH=/host/proc
 fi
 
+if [ -f /root/crashReport.sh ]; then
+  cp /root/crashReport.sh /opt/instana/agent/crashReport.sh
+
+  # Rewrite the Karaf script to make sure spaces in JAVA_OPTS are properly escaped (JAVA_OPTS is not within quotes)
+  sed -i "s|\ \${JAVA_OPTS}\ |\ \"\${JAVA_OPTS}\"\ |g" /opt/instana/agent/bin/karaf
+
+  FLAGS="-XX:OnError=\"/opt/instana/agent/crashReport.sh %p\" -XX:ErrorFile=/opt/instana/agent/hs_err.log -XX:OnOutOfMemoryError=\"/opt/instana/agent/crashReport.sh %p 'Out of Memory'\""
+  # Ensure to check if JAVA_OPTS are already configured, just including possibly existing JAVA_OPTS might introduce
+  # spaces when no options are set, which the Java command can't handle
+  if [ "x${JAVA_OPTS}" = "x" ]; then
+	export JAVA_OPTS="${FLAGS}"
+  else
+	export JAVA_OPTS="${JAVA_OPTS} ${FLAGS}"
+  fi
+fi
+
 echo "Starting Instana Agent ..."
 exec /opt/instana/agent/bin/karaf daemon

--- a/rhel/run.sh
+++ b/rhel/run.sh
@@ -130,7 +130,7 @@ if [ -f /root/crashReport.sh ]; then
   if [ "x${JAVA_OPTS}" = "x" ]; then
 	export JAVA_OPTS="${FLAGS}"
   else
-	export JAVA_OPTS="${JAVA_OPTS} ${FLAGS}"
+	export JAVA_OPTS="${FLAGS} ${JAVA_OPTS}"
   fi
 fi
 

--- a/rhel/util/.gitignore
+++ b/rhel/util/.gitignore
@@ -1,0 +1,1 @@
+crashReport.sh

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -33,6 +33,7 @@ ADD org.ops4j.pax.logging.cfg /root/
 ADD configuration.yaml /root/
 ADD com.instana.agent.main.sender.Backend.cfg.tmpl /root/
 ADD com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl /root/
+ADD util /root/
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/static/Dockerfile.s390x
+++ b/static/Dockerfile.s390x
@@ -33,6 +33,7 @@ ADD org.ops4j.pax.logging.cfg /root/
 ADD configuration.yaml /root/
 ADD com.instana.agent.main.sender.Backend.cfg.tmpl /root/
 ADD com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl /root/
+ADD util /root/
 ADD run.sh /opt/instana/agent/bin
 ADD gomplate /usr/bin
 

--- a/static/org.ops4j.pax.logging.cfg
+++ b/static/org.ops4j.pax.logging.cfg
@@ -1,5 +1,5 @@
 ################################################################################
-#    
+#
 #    Config file shipped by Apache Karaf under ASF license modified by Instana.
 #
 ################################################################################
@@ -30,7 +30,7 @@ log4j2.logger.instana.level = INFO
 
 # Root logger - Only change on request by support.
 log4j2.rootLogger.level = ERROR
-#log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
+log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
 log4j2.rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
 log4j2.rootLogger.appenderRef.Console.ref = Console
 #log4j2.rootLogger.appenderRef.Syslog.ref = Syslog
@@ -57,7 +57,9 @@ log4j2.appender.rolling.layout.type = PatternLayout
 log4j2.appender.rolling.layout.pattern = ${log4j2.pattern}
 log4j2.appender.rolling.policies.type = Policies
 log4j2.appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-log4j2.appender.rolling.policies.size.size = 2MB
+log4j2.appender.rolling.policies.size.size = 250KB
+log4j2.appender.rolling.strategy.type = DefaultRolloverStrategy
+log4j2.appender.rolling.strategy.max = 2
 
 # OSGi appender
 log4j2.appender.osgi.type = PaxOsgi
@@ -71,3 +73,4 @@ log4j2.appender.syslog.facility=SYSLOG
 log4j2.appender.syslog.host=localhost
 log4j2.appender.syslog.port=514
 log4j2.appender.syslog.protocol=UDP
+

--- a/static/run.sh
+++ b/static/run.sh
@@ -98,7 +98,7 @@ if [ -f /root/crashReport.sh ]; then
   if [ "x${JAVA_OPTS}" = "x" ]; then
 	export JAVA_OPTS="${FLAGS}"
   else
-	export JAVA_OPTS="${JAVA_OPTS} ${FLAGS}"
+	export JAVA_OPTS="${FLAGS} ${JAVA_OPTS}"
   fi
 fi
 

--- a/static/util/.gitignore
+++ b/static/util/.gitignore
@@ -1,0 +1,1 @@
+crashReport.sh

--- a/util/crashReport.sh
+++ b/util/crashReport.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
 # TODO
-# Add (and modify) Docker container, use -XX:OnError , -XX:OnOutOfMemoryError and -XX:ErrorFile
 # remove 'logging' echo statements
-# configure logging in Docker container to be picked up
-# Build script include utils in each context
-# Any other script improvements?
 
 # Variables for script usage
-FILE_HS_ERR_LOG=hs_err.log
-DIR_AGENT_LOG=data/log
+FILE_HS_ERR_LOG=/opt/instana/agent/hs_err.log
+DIR_AGENT_LOG=/opt/instana/agent/data/log
 AGENT_LOG_COLLECT_LINES=1000
 
 # Variables for use in the JSON payload

--- a/util/crashReport.sh
+++ b/util/crashReport.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# TODO
+# Add (and modify) Docker container, use -XX:OnError , -XX:OnOutOfMemoryError and -XX:ErrorFile
+# remove 'logging' echo statements
+# configure logging in Docker container to be picked up
+# Build script include utils in each context
+# Any other script improvements?
+
+# Variables for script usage
+FILE_HS_ERR_LOG=hs_err.log
+DIR_AGENT_LOG=data/log
+AGENT_LOG_COLLECT_LINES=1000
+
+# Variables for use in the JSON payload
+JSON_HOSTNAME="$(hostname)"
+JSON_TIMESTAMP="$(date +%s)000"
+JSON_PID="${1}"
+if [ "${2}" != "" ]; then
+  JSON_ERROR="${2}"
+else
+  JSON_ERROR="Unknown reason for Agent crash"
+fi
+
+
+post_crash_data() {
+  echo
+  echo $(generate_crash_data)
+  echo
+  # Silence all output so it doesn't show up in e.g. Docker or Kubernetes logs
+  curl -XPOST "https://${INSTANA_AGENT_ENDPOINT}:${INSTANA_AGENT_ENDPOINT_PORT}/metrics" \
+    --silent \
+	--http2-prior-knowledge \
+	--header "x-instana-key: ${INSTANA_AGENT_KEY}" \
+	--header "x-instana-host: ${JSON_HOSTNAME}" \
+	--header "Content-Type: application/json" \
+	--data "$(generate_crash_data)" \
+    --output /dev/null 2>&1
+  }
+
+#
+# Generates the JSON data for sending the crash report. Expects the following variables set:
+# - JSON_HOSTNAME: the hostname where the agent runs
+# - JSON_TIMESTAMP: timestamp when crash occurred
+# - JSON_PID: PID of the crashed Agent
+# - JSON_ERROR: the description of the error
+# - JSON_LOGS: Last log-lines captured from the agent
+#
+generate_crash_data() {
+  cat <<-EOF
+{
+  "plugins": [
+	{
+	  "name": "com.instana.agent",
+	  "hostId": "${JSON_HOSTNAME}",
+	  "entityId": "self",
+	  "data": {
+		"crashReport": {
+		  "timestamp": ${JSON_TIMESTAMP},
+		  "pid": "${JSON_PID}",
+		  "error": "${JSON_ERROR}",
+		  "logs": {
+			"hs_err_log": $(cat_file "${FILE_HS_ERR_LOG}" | format_to_json),
+			"agent_log": $(join_sort_dir "${DIR_AGENT_LOG}" | format_to_json)
+		  }
+		}
+	  }
+	}
+  ]
+}
+EOF
+
+}
+
+# Expects a directory as parameter, as contents inside are merged and sorted on timestamp and cat to stdout
+join_sort_dir() {
+  sort -m "$1"/* | tail -n ${AGENT_LOG_COLLECT_LINES} -
+}
+
+# Expects just a single file as parameter that will be cat to stdout, but with some handling for when
+# the file doesn't exist
+cat_file() {
+  # Dismiss any error output, which results in the empty string being returned.
+  # Another possibility is to redirect error to stdin so the warning shows up for the file.
+  cat "$1" 2>/dev/null
+}
+
+format_to_json() {
+  python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
+
+post_crash_data

--- a/util/crashReport.sh
+++ b/util/crashReport.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# TODO
-# remove 'logging' echo statements
-
 # Variables for script usage
 FILE_HS_ERR_LOG=/opt/instana/agent/hs_err.log
 DIR_AGENT_LOG=/opt/instana/agent/data/log
@@ -20,13 +17,15 @@ fi
 
 
 post_crash_data() {
-  echo
-  echo $(generate_crash_data)
-  echo
+  #echo
+  #echo $(generate_crash_data)
+  #echo
   # Silence all output so it doesn't show up in e.g. Docker or Kubernetes logs
   curl -XPOST "https://${INSTANA_AGENT_ENDPOINT}:${INSTANA_AGENT_ENDPOINT_PORT}/metrics" \
     --silent \
 	--http2-prior-knowledge \
+	--connect-timeout 5 \
+	--max-time 30 \
 	--header "x-instana-key: ${INSTANA_AGENT_KEY}" \
 	--header "x-instana-host: ${JSON_HOSTNAME}" \
 	--header "Content-Type: application/json" \


### PR DESCRIPTION
When the Agent crashes for any unknown reason (e.g. JVM issue or OutOfMemoryError) send a crash report back to Instana containing some data such as the hs_err log file and latest Agent logs.

When the Agent crashes in any unlikely event, because its containerized, in general all data will get lost with it. Adding a hook to the JVM will make it invoke the `crashReport.sh` script and possibly collect some remaining data for investigation by us.