### PR TITLE
Better modularize the Ubuntu-based Docker-files

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -26,15 +26,25 @@ ENV LANG=C.UTF-8 \
     INSTANA_REPOSITORY_PROXY_PASSWORD="" \
     INSTANA_REPOSITORY_PROXY_USE_DNS=""
 
+# Setup of dependencies we need inside the container
 RUN apt-get update && \
     apt-get install -y gnupg2 ca-certificates curl && \
-    echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
-    apt-get install -y instana-agent-dynamic inotify-tools gomplate docker-ce-cli containerd.io python-pip iptables && \
-    apt-get purge -y gnupg2 && \
+    apt-get install -y inotify-tools docker-ce-cli containerd python-pip iptables && \
+    apt-get clean
+
+# Setup to install the Instana package
+RUN echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
+    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
+    apt-get update && \
+    apt-get install -y gomplate
+
+RUN apt-get install -y instana-agent-dynamic
+
+# Cleanup
+RUN apt-get purge -y gnupg2 && \
     apt-get autoremove -y && \
     rm -rf /etc/apt/sources.list.d/instana-agent.list && \
     rm -rf /var/lib/apt/lists/* && \

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -1,5 +1,21 @@
 FROM ubuntu:18.04
 
+# Setup of dependencies we need inside the container
+RUN apt-get update && \
+    apt-get install -y gnupg2 ca-certificates curl && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
+    apt-get update && \
+    apt-get install -y inotify-tools docker-ce-cli containerd python-pip iptables && \
+    apt-get clean
+
+# Setup to install the Instana package
+RUN echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
+    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
+    apt-get update && \
+    apt-get install -y gomplate && \
+    apt-get clean
+
 ENV LANG=C.UTF-8 \
     INSTANA_AGENT_KEY="" \
     INSTANA_DOWNLOAD_KEY="" \
@@ -26,21 +42,6 @@ ENV LANG=C.UTF-8 \
     INSTANA_REPOSITORY_PROXY_PASSWORD="" \
     INSTANA_REPOSITORY_PROXY_USE_DNS=""
 
-# Setup of dependencies we need inside the container
-RUN apt-get update && \
-    apt-get install -y gnupg2 ca-certificates curl && \
-    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
-    apt-get update && \
-    apt-get install -y inotify-tools docker-ce-cli containerd python-pip iptables && \
-    apt-get clean
-
-# Setup to install the Instana package
-RUN echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
-    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
-    apt-get update && \
-    apt-get install -y gomplate
-
 RUN apt-get install -y instana-agent-dynamic
 
 # Cleanup
@@ -50,13 +51,7 @@ RUN apt-get purge -y gnupg2 && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-ADD org.ops4j.pax.logging.cfg /root/
-ADD org.ops4j.pax.url.mvn.cfg /root/
-ADD configuration.yaml /root/
-ADD com.instana.agent.main.sender.Backend.cfg.tmpl /root/
-ADD com.instana.agent.main.config.UpdateManager.cfg.tmpl /root/
-ADD com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl /root/
-ADD mvn-settings.xml.tmpl /root/
+COPY org.ops4j.pax.logging.cfg org.ops4j.pax.url.mvn.cfg configuration.yaml com.instana.agent.main.sender.Backend.cfg.tmpl com.instana.agent.main.config.UpdateManager.cfg.tmpl com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl mvn-settings.xml.tmpl /root/
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -15,15 +15,25 @@ ENV LANG=C.UTF-8 \
     INSTANA_AGENT_PROXY_USER="" \
     INSTANA_AGENT_PROXY_USE_DNS=""
 
+# Dependencies we need inside the container
 RUN apt-get update && \
     apt-get install -y gnupg2 ca-certificates curl && \
-    echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
-    apt-get install -y instana-agent-static inotify-tools gomplate docker-ce-cli containerd python-pip iptables && \
-    apt-get purge -y gnupg2 && \
+    apt-get install -y inotify-tools docker-ce-cli containerd python-pip iptables && \
+    apt-get clean
+
+# Setup to install the Instana package
+RUN echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
+    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
+    apt-get update && \
+    apt-get install -y gomplate
+
+RUN apt-get install -y instana-agent-static
+
+# Cleanup
+RUN apt-get purge -y gnupg2 && \
     apt-get autoremove -y && \
     rm -rf /etc/apt/sources.list.d/instana-agent.list && \
     rm -rf /var/lib/apt/lists/* && \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -1,5 +1,21 @@
 FROM ubuntu:18.04
 
+# Setup of dependencies we need inside the container
+RUN apt-get update && \
+    apt-get install -y gnupg2 ca-certificates curl && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
+    apt-get update && \
+    apt-get install -y inotify-tools docker-ce-cli containerd python-pip iptables && \
+    apt-get clean
+
+# Setup to install the Instana package
+RUN echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
+    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
+    apt-get update && \
+    apt-get install -y gomplate && \
+    apt-get clean
+
 ENV LANG=C.UTF-8 \
     INSTANA_AGENT_KEY="" \
     INSTANA_AGENT_ENDPOINT="" \
@@ -15,21 +31,6 @@ ENV LANG=C.UTF-8 \
     INSTANA_AGENT_PROXY_USER="" \
     INSTANA_AGENT_PROXY_USE_DNS=""
 
-# Dependencies we need inside the container
-RUN apt-get update && \
-    apt-get install -y gnupg2 ca-certificates curl && \
-    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
-    apt-get update && \
-    apt-get install -y inotify-tools docker-ce-cli containerd python-pip iptables && \
-    apt-get clean
-
-# Setup to install the Instana package
-RUN echo "deb [arch=amd64] https://_:${FTP_PROXY}@packages.instana.io/agent/deb generic main" > /etc/apt/sources.list.d/instana-agent.list && \
-    apt-key adv --fetch-keys "https://packages.instana.io/Instana.gpg" && \
-    apt-get update && \
-    apt-get install -y gomplate
-
 RUN apt-get install -y instana-agent-static
 
 # Cleanup
@@ -39,10 +40,7 @@ RUN apt-get purge -y gnupg2 && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-ADD org.ops4j.pax.logging.cfg /root/
-ADD configuration.yaml /root/
-ADD com.instana.agent.main.sender.Backend.cfg.tmpl /root/
-ADD com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl /root/
+COPY org.ops4j.pax.logging.cfg configuration.yaml com.instana.agent.main.sender.Backend.cfg.tmpl com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl /root/
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent


### PR DESCRIPTION
Shoot to reuse as many OCI layers as possible to reduce tile size with PKS support.