### PR TITLE
Always attempt to pull a newer version of the base image during docker build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ def buildImage(name, context) {
   try {
     sh """
       cp -r ./util ./${context}/
-      docker build ./${context} --build-arg FTP_PROXY=${INSTANA_AGENT_KEY} --no-cache -t ${name}:${INSTANA_AGENT_RELEASE}
+      docker build --pull ./${context} --build-arg FTP_PROXY=${INSTANA_AGENT_KEY} --no-cache -t ${name}:${INSTANA_AGENT_RELEASE}
     """
   } catch(e) {
     slackSend channel: "#${SLACK_CHANNEL}",


### PR DESCRIPTION
# Why

> Avoid vusecurity vulnerabilities during agent docker image build.

# What

> Add --pull option in docker build command in Jenkins file.