### PR TITLE
Install Nvidia driver - GPU monitoring

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables && \
+    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables nvidia-driver-435 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Nvidia driver is necessary for GPU monitoring. 
This PR is still WIP, please don't merge it yet. 