### PR TITLE
Reinstate the installation of iptables for the rhel Agent image

### DIFF
--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7-atomic:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 LABEL name="instana-agent" \
       vendor="Instana Inc." \
@@ -41,7 +41,7 @@ ADD docker.repo /etc/yum.repos.d/docker.repo
 RUN curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     rpm --import /tmp/Instana.gpg && \
     echo -e "[instana-agent]\nname=Instana\nbaseurl=https://_:${FTP_PROXY}@packages.instana.io/agent/generic/x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.instana.io/Instana.gpg\nsslverify=1" > /etc/yum.repos.d/Instana-Agent.repo && \
-    microdnf install instana-agent-dynamic docker-ce-cli && \
+    microdnf install instana-agent-dynamic docker-ce-cli iptables && \
     curl -L https://github.com/hairyhenderson/gomplate/releases/download/v3.6.0/gomplate_linux-amd64-slim -o /usr/bin/gomplate && \
     chmod 755 /usr/bin/gomplate && \
     rm -rf /tmp/* /etc/yum.repos.d/Instana-Agent.repo /etc/yum.repos.d/docker.repo && \


### PR DESCRIPTION
When we fixed the RHEL image build in #36, we had to remove the installation of `iptables-services` as it wasn't able to find that package at all using the `rhel7-atomic` base image. As a matter of fact, `microdnf` was not able to install much of anything on that base image. See [this](https://access.redhat.com/discussions/3219221) forum discussion thread.

[This documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/using_red_hat_universal_base_images_standard_minimal_and_runtimes) indicates the the `rhel*` images require a RHEL paid subscription, which is why it wasn't able to install anything before on `rhel7-atomic`.

Switch to using `ubi7/ubi-minimal` as the base image for the rhel Agent image so we can reinstate the installation of `iptables`.`iptables` is needed to support service mesh bypass on the Agent: https://docs.instana.io/ecosystem/kubernetes/#istio

`microdnf install iptables` and `microdnf install iptables-services` both do NOT work on the `rhel7-atomic` base image. However, `microdnf install iptables` works on `ubi7/ubi-minimal`.

I built this image locally, then installed the agent using this image on a local minikube cluster, then followed our docs ☝️ to exec into the agent pod and run `iptables -t nat -L` and it was able to execute that command.