### PR TITLE
Preliminary integration of GitOps in Docker dynamic image

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -39,6 +39,8 @@ ENV LANG=C.UTF-8 \
     INSTANA_AGENT_PROXY_PROTOCOL="" \
     INSTANA_AGENT_PROXY_USER="" \
     INSTANA_AGENT_PROXY_USE_DNS="" \
+    INSTANA_GIT_REMOTE_REPOSITORY=""\
+    INSTANA_GIT_REMOTE_BRANCH=""\
     INSTANA_REPOSITORY_PROXY_ENABLED="false" \
     INSTANA_REPOSITORY_PROXY_HOST="" \
     INSTANA_REPOSITORY_PROXY_PORT="" \
@@ -51,9 +53,9 @@ ENV LANG=C.UTF-8 \
     INSTANA_MVN_REPOSITORY_SHARED_PATH="" \
     INSTANA_LOG_LEVEL=""
 
-
 RUN apt-get update && \
     apt-get install -y instana-agent-dynamic && \
+    apt-get install -y git && \
     apt-get purge -y gnupg2 && \
     apt-get autoremove -y && \
     rm -rf /etc/apt/sources.list.d/instana-agent.list && \
@@ -68,6 +70,7 @@ COPY org.ops4j.pax.logging.cfg.tmpl \
   com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl \
   mvn-settings.xml.tmpl \
   /root/
+
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -154,5 +154,16 @@ if [ -f /root/crashReport.sh ] && [ -z "${INSTANA_DISABLE_CRASH_REPORT}" ]; then
 
 fi
 
+if [ ! -z "${INSTANA_GIT_REMOTE_REPOSITORY}" ]; then
+  echo "Initializing GitOps integration with remote repository '${INSTANA_GIT_REMOTE_REPOSITORY}' and remote branch '${INSTANA_GIT_REMOTE_BRANCH}'"
+
+  (
+    cd /opt/instana/agent/etc && git init && \
+    git remote add -m ${INSTANA_GIT_REMOTE_BRANCH} -t ${INSTANA_GIT_REMOTE_BRANCH} configuration ${INSTANA_GIT_REMOTE_REPOSITORY} && \
+    git fetch configuration ${INSTANA_GIT_REMOTE_BRANCH} && \
+    git checkout -f -b ${INSTANA_GIT_REMOTE_BRANCH} --track configuration/${INSTANA_GIT_REMOTE_BRANCH}
+  )
+fi
+
 echo "Starting Instana Agent ..."
 exec /opt/instana/agent/bin/karaf daemon


### PR DESCRIPTION
This commit adds to the dynamic Docker agent image a Git client and the commands to initialize the Git repository in `/opt/instana/agent/etc`. The remote repository and branch to be used are provided via the `INSTANA_GIT_REMOTE_REPOSITORY` and `INSTANA_GIT_REMOTE_BRANCH` environment variables, for example:

```sh
--env="INSTANA_GIT_REMOTE_REPOSITORY=https://github.com/mmanciop/gitops-test.git"
--env="INSTANA_GIT_REMOTE_BRANCH=master"
```

This change will not be merged to the main codebase. Instead, we are going to extend the capability of the agent later on to perform the required initialization steps automatically when the environment variables listed above are discovered.