### PR TITLE
Support AWS mode on ECS

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
+    apt-get install -y --no-install-recommends jq && \
     apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables && \
     apt-get upgrade -y && \
     apt-get clean && \
@@ -51,7 +52,6 @@ ENV LANG=C.UTF-8 \
     INSTANA_MVN_REPOSITORY_SHARED_PATH="" \
     INSTANA_LOG_LEVEL=""
 
-
 RUN apt-get update && \
     apt-get install -y instana-agent-dynamic && \
     apt-get purge -y gnupg2 && \
@@ -61,13 +61,14 @@ RUN apt-get update && \
     apt-get clean
 
 COPY org.ops4j.pax.logging.cfg.tmpl \
-  org.ops4j.pax.url.mvn.cfg.tmpl \
-  configuration.yaml \
-  com.instana.agent.main.sender.Backend-1.cfg.tmpl \
-  com.instana.agent.main.config.UpdateManager.cfg.tmpl \
-  com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl \
-  mvn-settings.xml.tmpl \
-  /root/
+    org.ops4j.pax.url.mvn.cfg.tmpl \
+    configuration.yaml \
+    com.instana.agent.main.sender.Backend-1.cfg.tmpl \
+    com.instana.agent.main.config.UpdateManager.cfg.tmpl \
+    com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl \
+    mvn-settings.xml.tmpl \
+    /root/
+
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update && \
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends jq && \
-    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables && \
+    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables jq && \
     apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -43,7 +43,11 @@ RUN curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     echo -e "[instana-agent]\nname=Instana\nbaseurl=https://_:${FTP_PROXY}@packages.instana.io/agent/generic/x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.instana.io/Instana.gpg\nsslverify=1" > /etc/yum.repos.d/Instana-Agent.repo && \
     microdnf install instana-agent-dynamic docker-ce-cli iptables && \
     curl -L https://github.com/hairyhenderson/gomplate/releases/download/v3.6.0/gomplate_linux-amd64-slim -o /usr/bin/gomplate && \
+    echo "0867b2d6b23c70143a4ea37705d4308d051317dd0532d7f3063acec21f6cbbc8 /usr/bin/gomplate" | sha256sum -c - > /dev/null && \
     chmod 755 /usr/bin/gomplate && \
+    curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq && \
+    echo "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44 /usr/bin/jq" | sha256sum -c - > /dev/null && \
+    chmod 755 /usr/bin/jq && \
     rm -rf /tmp/* /etc/yum.repos.d/Instana-Agent.repo /etc/yum.repos.d/docker.repo && \
     microdnf clean all && \
     curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq && \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -45,19 +45,22 @@ RUN curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     curl -L https://github.com/hairyhenderson/gomplate/releases/download/v3.6.0/gomplate_linux-amd64-slim -o /usr/bin/gomplate && \
     chmod 755 /usr/bin/gomplate && \
     rm -rf /tmp/* /etc/yum.repos.d/Instana-Agent.repo /etc/yum.repos.d/docker.repo && \
-    microdnf clean all
+    microdnf clean all && \
+    curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq && \
+    chmod u+x /usr/bin/jq
 
 ADD licenses/* /licenses/
 ADD help.1 /help.1
 
 COPY org.ops4j.pax.logging.cfg.tmpl \
-  org.ops4j.pax.url.mvn.cfg.tmpl \
-  configuration.yaml \
-  com.instana.agent.main.sender.Backend-1.cfg.tmpl \
-  com.instana.agent.main.config.UpdateManager.cfg.tmpl \
-  com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl \
-  mvn-settings.xml.tmpl \
-  /root/
+    org.ops4j.pax.url.mvn.cfg.tmpl \
+    configuration.yaml \
+    com.instana.agent.main.sender.Backend-1.cfg.tmpl \
+    com.instana.agent.main.config.UpdateManager.cfg.tmpl \
+    com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl \
+    mvn-settings.xml.tmpl \
+    /root/
+
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/rhel/com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl
+++ b/rhel/com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl
@@ -2,4 +2,4 @@
 version = {{ getenv "INSTANA_AGENT_UPDATES_VERSION" }}
 {{- end }}
 
-origin = public_docker
+origin = public_docker_rhel

--- a/rhel/run.sh
+++ b/rhel/run.sh
@@ -92,53 +92,133 @@ rm -rf /tmp/* /opt/instana/agent/etc/org.ops4j.pax.logging.cfg \
   /opt/instana/agent/etc/instana/com.instana.agent.main.config.UpdateManager.cfg \
   /opt/instana/agent/etc/instana/com.instana.agent.bootstrap.AgentBootstrap.cfg
 
-
 cp /root/configuration.yaml /opt/instana/agent/etc/instana
 cp /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg.template /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
-cat /root/org.ops4j.pax.logging.cfg.tmpl | gomplate > /opt/instana/agent/etc/org.ops4j.pax.logging.cfg
-cat /root/org.ops4j.pax.url.mvn.cfg.tmpl | gomplate > /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg
-cat /root/mvn-settings.xml.tmpl | gomplate > /opt/instana/agent/etc/mvn-settings.xml
-cat /root/com.instana.agent.main.sender.Backend-1.cfg.tmpl | gomplate > \
+gomplate < /root/org.ops4j.pax.logging.cfg.tmpl > /opt/instana/agent/etc/org.ops4j.pax.logging.cfg
+gomplate < /root/org.ops4j.pax.url.mvn.cfg.tmpl > /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg
+gomplate < /root/mvn-settings.xml.tmpl > /opt/instana/agent/etc/mvn-settings.xml
+gomplate < /root/com.instana.agent.main.sender.Backend-1.cfg.tmpl > \
   /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg
-cat /root/com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl | gomplate > \
+gomplate < /root/com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl > \
   /opt/instana/agent/etc/instana/com.instana.agent.bootstrap.AgentBootstrap.cfg
-cat /root/com.instana.agent.main.config.UpdateManager.cfg.tmpl | gomplate > \
+gomplate < /root/com.instana.agent.main.config.UpdateManager.cfg.tmpl > \
   /opt/instana/agent/etc/instana/com.instana.agent.main.config.UpdateManager.cfg
 
-if [ ! -z "${INSTANA_AGENT_HTTP_LISTEN}" ]; then
+if [ -n "${INSTANA_AGENT_HTTP_LISTEN}" ]; then
   echo -e "\nhttp.listen = ${INSTANA_AGENT_HTTP_LISTEN}" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
 fi
 
-if [ ! -z "${INSTANA_AGENT_MODE}" ]; then
-  if [ "${INSTANA_AGENT_MODE}" = "AWS" ]; then
+if [ "${INSTANA_AGENT_MODE}" = 'AWS' ]; then
+  echo 'AWS mode configured'
 
-    INSTANA_AWS_REGION_CONFIG=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document --connect-timeout 2 | awk -F\" '/region/ {print $4}')
+  ###
+  # Discover which platform we are running on
+  ###
+  if [ -n "${ECS_CONTAINER_METADATA_URI}" ]; then
+    PLATFORM='ECS'
+    echo 'Running on ECS'
+  elif curl -s http://169.254.169.254/latest/meta-data/ --connect-timeout 2 --fail 2>&1 /dev/null; then
+    PLATFORM='EC2'
+    echo 'Running on EC2'
+  else
+    PLATFORM='UNKNOWN'
+    echo 'Cannot recognize the platform; it is neither ECS nor EC2'
+  fi
 
-    if [ $? != 0 ]; then
-      log_error "Error querying AWS metadata."
+  ###
+  # Retrieve region
+  ###
+  if [ -n "${INSTANA_AWS_REGION_CONFIG}" ]; then
+    echo "AWS region configured via environment: ${INSTANA_AWS_REGION_CONFIG}"
+  else
+    case "${PLATFORM}" in
+
+    'ECS')
+      if ! curl -s "${ECS_CONTAINER_METADATA_URI}/task" --connect-timeout 2 --fail -o /tmp/ecs_data; then
+        echo "Cannot retrieve metadata from the '${ECS_CONTAINER_METADATA_URI}/task' endpoint. Aborting startup."
+        exit 1
+      fi
+
+      if AWS_AVAILABILITY_ZONE=$(jq -e -r '.AvailabilityZone' < /tmp/ecs_data); then
+        # The -e flag of jq will make it fail on purpose, if the data do not contain the 'AvailabilityZone' key
+        readonly ARN_REGEXP='^([a-z]+-[a-z]+-[0-9])*'
+        if [[ "${AWS_AVAILABILITY_ZONE}" =~ ${ARN_REGEXP} ]]; then
+          echo "AWS region parsed from the availability zone"
+          INSTANA_AWS_REGION_CONFIG="${BASH_REMATCH[1]}"
+        else
+          echo "Cannot parse the AWS region from the availability zone '${AWS_AVAILABILITY_ZONE}' retrieved from the '${ECS_CONTAINER_METADATA_URI}/task' endpoint. Aborting startup."
+          cat /tmp/ecs_data
+          exit 1
+        fi
+      elif INSTANA_AWS_REGION_CONFIG=$(jq -e -r '.Cluster' | awk -F ':' '{ print $5 }' < /tmp/ecs_data); then
+        # The -e flag of jq will make it fail on purpose, if the data do not contain the 'Cluster' key
+        echo "Metadata endpoint did not return the availability zone; parsing the region from the ARN."
+      else
+        echo "Cannot parse the AWS region from the data retrieved from the '${ECS_CONTAINER_METADATA_URI}/task' endpoint. Aborting startup."
+        cat /tmp/ecs_data
+        exit 1
+      fi
+      ;;
+
+    'EC2')
+      readonly EC2_METADATA_ENDPOINT='http://169.254.169.254/latest/dynamic/instance-identity/document'
+
+      if ! curl -s "${EC2_METADATA_ENDPOINT}" --connect-timeout 2 --fail -o /tmp/ec2_data; then
+        echo "Cannot retrieve metadata from the '${EC2_METADATA_ENDPOINT}' endpoint. Aborting startup."
+        exit 1
+      fi
+
+      if ! INSTANA_AWS_REGION_CONFIG=$(jq -e -r '.region' < /tmp/ec2_data); then
+        echo "The metadata endpoint did not return the 'region' key. Aborting startup."
+        cat /tmp/ecs_data
+        exit 1
+      fi
+      ;;
+
+    *)
+      if [ -n "${AWS_DEFAULT_REGION}" ]; then
+        echo "Using the default AWS region '${AWS_DEFAULT_REGION}' set in the environment via the 'AWS_DEFAULT_REGION' environment variable."
+        INSTANA_AWS_REGION_CONFIG="${AWS_DEFAULT_REGION}"
+      else
+        echo "Platform not recognized: this agent does not seem to run on EC2 or ECS. Set the 'INSTANA_AWS_REGION_CONFIG' environment variable. Aborting startup."
+        exit 1
+      fi
+      ;;
+    esac
+
+    if [ -z "${INSTANA_AWS_REGION_CONFIG}" ]; then
+      echo "Could not retrieve the AWS region from the AWS metadata. Aborting startup."
       exit 1
     fi
 
+    echo "Discovered AWS region: ${INSTANA_AWS_REGION_CONFIG}"
     export INSTANA_AWS_REGION_CONFIG
+  fi
 
-    ROLES_FOUND=false
-
-    if ! curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/ --connect-timeout 2 | grep 404&> /dev/null; then
-      ROLES_FOUND=true
+  if [ "${PLATFORM}" = 'UNKNOWN' ]; then
+    if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+      echo "The platform is not recognized (this agent does not seem to run on EC2 or ECS) and neither 'AWS_ACCESS_KEY_ID' nor 'AWS_SECRET_ACCESS_KEY' environment variables are exported. AWS Services monitoring might just not work. If so, please configure either the 'AWS_ACCESS_KEY_ID' or the 'AWS_SECRET_ACCESS_KEY' environment variables."
     fi
-
-    if [ "$ROLES_FOUND" = "false" ]; then
-      if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-        echo "AWS_ACCESS_KEY_ID and/or AWS_SECRET_ACCESS_KEY not exported, and no IAM instance role detected to allow AWS API access."
-        exit 1
-      fi
-    fi
-
-    echo -e "\nmode = INFRASTRUCTURE" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
-  else
-    echo -e "\nmode = ${INSTANA_AGENT_MODE}" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
   fi
 fi
+
+# Normalize the Agent mode to those that are actually used by the agent itself, i.e., OFF, APM and INFRASTRUCTURE
+case "${INSTANA_AGENT_MODE}" in
+  'AWS')
+    INSTANA_AGENT_MODE='INFRASTRUCTURE'
+    ;; # The AWS agent mode is infra + AWS sensor setup
+  'INFRASTRUCTURE')
+    ;;
+  'APM')
+    ;;
+  'OFF')
+    ;;
+  *)
+    echo "Unknown agent mode ${INSTANA_AGENT_MODE}"
+    exit 1;
+esac
+
+echo -e "\nmode = ${INSTANA_AGENT_MODE}" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
 
 if [ -d /host/proc ]; then
   export INSTANA_AGENT_PROC_PATH=/host/proc
@@ -152,7 +232,6 @@ if [ -f /root/crashReport.sh ] && [ -z "${INSTANA_DISABLE_CRASH_REPORT}" ]; then
   # Therefore instead modify the script directly so we can properly include the quotes and spaces are escaped correctly.
   FLAGS="-XX:OnError=\"/opt/instana/agent/crashReport.sh %p\" -XX:ErrorFile=/opt/instana/agent/hs_err.log -XX:OnOutOfMemoryError=\"/opt/instana/agent/crashReport.sh %p 'Out of Memory'\""
   sed -i "s|\ \${JAVA_OPTS}\ |\ \${JAVA_OPTS}\ ${FLAGS} |g" /opt/instana/agent/bin/karaf
-
 fi
 
 echo "Starting Instana Agent ..."

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
+    apt-get install -y --no-install-recommends jq && \
     apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables && \
     apt-get upgrade -y && \
     apt-get clean && \
@@ -46,10 +47,11 @@ RUN apt-get update && \
     apt-get clean
 
 COPY org.ops4j.pax.logging.cfg.tmpl \
-  configuration.yaml \
-  com.instana.agent.main.sender.Backend-1.cfg.tmpl \
-  com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl \
-  /root/
+    configuration.yaml \
+    com.instana.agent.main.sender.Backend-1.cfg.tmpl \
+    com.instana.agent.bootstrap.AgentBootstrap.cfg.tmpl \
+    /root/
+
 ADD run.sh /opt/instana/agent/bin
 
 WORKDIR /opt/instana/agent

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update && \
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends jq && \
-    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables && \
+    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables jq && \
     apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/static/run.sh
+++ b/static/run.sh
@@ -55,46 +55,126 @@ cp /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg.template /opt/instana/agent/
 touch /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
 
 cp /root/configuration.yaml /opt/instana/agent/etc/instana
-cat /root/org.ops4j.pax.logging.cfg.tmpl | gomplate > /opt/instana/agent/etc/org.ops4j.pax.logging.cfg
-cat /root/com.instana.agent.main.sender.Backend-1.cfg.tmpl | gomplate > \
+gomplate < /root/org.ops4j.pax.logging.cfg.tmpl > /opt/instana/agent/etc/org.ops4j.pax.logging.cfg
+gomplate < /root/com.instana.agent.main.sender.Backend-1.cfg.tmpl > \
   /opt/instana/agent/etc/instana/com.instana.agent.main.sender.Backend-1.cfg
 
-echo "origin = static_docker" >> /opt/instana/agent/etc/instana/com.instana.agent.bootstrap.AgentBootstrap.cfg
-
-if [ ! -z "${INSTANA_AGENT_HTTP_LISTEN}" ]; then
+if [ -n "${INSTANA_AGENT_HTTP_LISTEN}" ]; then
   echo -e "\nhttp.listen = ${INSTANA_AGENT_HTTP_LISTEN}" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
 fi
 
-if [ ! -z "${INSTANA_AGENT_MODE}" ]; then
-  if [ "${INSTANA_AGENT_MODE}" = "AWS" ]; then
+# No jq on s390x. Also, an AWS sensor running on s390x is every bit as likely as Xmas in August
+if which jq > /dev/null && [ "${INSTANA_AGENT_MODE}" = 'AWS' ]; then
+  echo 'AWS mode configured'
 
-    INSTANA_AWS_REGION_CONFIG=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document --connect-timeout 2 | awk -F\" '/region/ {print $4}')
+  ###
+  # Discover which platform we are running on
+  ###
+  if [ -n "${ECS_CONTAINER_METADATA_URI}" ]; then
+    PLATFORM='ECS'
+    echo 'Running on ECS'
+  elif curl -s http://169.254.169.254/latest/meta-data/ --connect-timeout 2 --fail 2>&1 /dev/null; then
+    PLATFORM='EC2'
+    echo 'Running on EC2'
+  else
+    PLATFORM='UNKNOWN'
+    echo 'Cannot recognize the platform; it is neither ECS nor EC2'
+  fi
 
-    if [ $? != 0 ]; then
-      log_error "Error querying AWS metadata."
+  ###
+  # Retrieve region
+  ###
+  if [ -n "${INSTANA_AWS_REGION_CONFIG}" ]; then
+    echo "AWS region configured via environment: ${INSTANA_AWS_REGION_CONFIG}"
+  else
+    case "${PLATFORM}" in
+
+    'ECS')
+      if ! curl -s "${ECS_CONTAINER_METADATA_URI}/task" --connect-timeout 2 --fail -o /tmp/ecs_data; then
+        echo "Cannot retrieve metadata from the '${ECS_CONTAINER_METADATA_URI}/task' endpoint. Aborting startup."
+        exit 1
+      fi
+
+      if AWS_AVAILABILITY_ZONE=$(jq -e -r '.AvailabilityZone' < /tmp/ecs_data); then
+        # The -e flag of jq will make it fail on purpose, if the data do not contain the 'AvailabilityZone' key
+        readonly ARN_REGEXP='^([a-z]+-[a-z]+-[0-9])*'
+        if [[ "${AWS_AVAILABILITY_ZONE}" =~ ${ARN_REGEXP} ]]; then
+          echo "AWS region parsed from the availability zone"
+          INSTANA_AWS_REGION_CONFIG="${BASH_REMATCH[1]}"
+        else
+          echo "Cannot parse the AWS region from the availability zone '${AWS_AVAILABILITY_ZONE}' retrieved from the '${ECS_CONTAINER_METADATA_URI}/task' endpoint. Aborting startup."
+          cat /tmp/ecs_data
+          exit 1
+        fi
+      elif INSTANA_AWS_REGION_CONFIG=$(jq -e -r '.Cluster' | awk -F ':' '{ print $5 }' < /tmp/ecs_data); then
+        # The -e flag of jq will make it fail on purpose, if the data do not contain the 'Cluster' key
+        echo "Metadata endpoint did not return the availability zone; parsing the region from the ARN."
+      else
+        echo "Cannot parse the AWS region from the data retrieved from the '${ECS_CONTAINER_METADATA_URI}/task' endpoint. Aborting startup."
+        cat /tmp/ecs_data
+        exit 1
+      fi
+      ;;
+
+    'EC2')
+      readonly EC2_METADATA_ENDPOINT='http://169.254.169.254/latest/dynamic/instance-identity/document'
+
+      if ! curl -s "${EC2_METADATA_ENDPOINT}" --connect-timeout 2 --fail -o /tmp/ec2_data; then
+        echo "Cannot retrieve metadata from the '${EC2_METADATA_ENDPOINT}' endpoint. Aborting startup."
+        exit 1
+      fi
+
+      if ! INSTANA_AWS_REGION_CONFIG=$(jq -e -r '.region' < /tmp/ec2_data); then
+        echo "The metadata endpoint did not return the 'region' key. Aborting startup."
+        cat /tmp/ecs_data
+        exit 1
+      fi
+      ;;
+
+    *)
+      if [ -n "${AWS_DEFAULT_REGION}" ]; then
+        echo "Using the default AWS region '${AWS_DEFAULT_REGION}' set in the environment via the 'AWS_DEFAULT_REGION' environment variable."
+        INSTANA_AWS_REGION_CONFIG="${AWS_DEFAULT_REGION}"
+      else
+        echo "Platform not recognized: this agent does not seem to run on EC2 or ECS. Set the 'INSTANA_AWS_REGION_CONFIG' environment variable. Aborting startup."
+        exit 1
+      fi
+      ;;
+    esac
+
+    if [ -z "${INSTANA_AWS_REGION_CONFIG}" ]; then
+      echo "Could not retrieve the AWS region from the AWS metadata. Aborting startup."
       exit 1
     fi
 
+    echo "Discovered AWS region: ${INSTANA_AWS_REGION_CONFIG}"
     export INSTANA_AWS_REGION_CONFIG
+  fi
 
-    ROLES_FOUND=false
-
-    if ! curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/ --connect-timeout 2 | grep 404&> /dev/null; then
-      ROLES_FOUND=true
+  if [ "${PLATFORM}" = 'UNKNOWN' ]; then
+    if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+      echo "The platform is not recognized (this agent does not seem to run on EC2 or ECS) and neither 'AWS_ACCESS_KEY_ID' nor 'AWS_SECRET_ACCESS_KEY' environment variables are exported. AWS Services monitoring might just not work. If so, please configure either the 'AWS_ACCESS_KEY_ID' or the 'AWS_SECRET_ACCESS_KEY' environment variables."
     fi
-
-    if [ "$ROLES_FOUND" = "false" ]; then
-      if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-        echo "AWS_ACCESS_KEY_ID and/or AWS_SECRET_ACCESS_KEY not exported, and no IAM instance role detected to allow AWS API access."
-        exit 1
-      fi
-    fi
-
-    echo -e "\nmode = INFRASTRUCTURE" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
-  else
-    echo -e "\nmode = ${INSTANA_AGENT_MODE}" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
   fi
 fi
+
+# Normalize the Agent mode to those that are actually used by the agent itself, i.e., OFF, APM and INFRASTRUCTURE
+case "${INSTANA_AGENT_MODE}" in
+  'AWS')
+    INSTANA_AGENT_MODE='INFRASTRUCTURE'
+    ;; # The AWS agent mode is infra + AWS sensor setup
+  'INFRASTRUCTURE')
+    ;;
+  'APM')
+    ;;
+  'OFF')
+    ;;
+  *)
+    echo "Unknown agent mode ${INSTANA_AGENT_MODE}"
+    exit 1;
+esac
+
+echo -e "\nmode = ${INSTANA_AGENT_MODE}" >> /opt/instana/agent/etc/instana/com.instana.agent.main.config.Agent.cfg
 
 if [ -d /host/proc ]; then
   export INSTANA_AGENT_PROC_PATH=/host/proc
@@ -108,7 +188,6 @@ if [ -f /root/crashReport.sh ] && [ -z "${INSTANA_DISABLE_CRASH_REPORT}" ]; then
   # Therefore instead modify the script directly so we can properly include the quotes and spaces are escaped correctly.
   FLAGS="-XX:OnError=\"/opt/instana/agent/crashReport.sh %p\" -XX:ErrorFile=/opt/instana/agent/hs_err.log -XX:OnOutOfMemoryError=\"/opt/instana/agent/crashReport.sh %p 'Out of Memory'\""
   sed -i "s|\ \${JAVA_OPTS}\ |\ \${JAVA_OPTS}\ ${FLAGS} |g" /opt/instana/agent/bin/karaf
-
 fi
 
 echo "Starting Instana Agent ..."


### PR DESCRIPTION
* Add `jq` to the images via Dockerfile, with the exception of the s390x Dockerfile, because (a) no idea where to find `jq` for s390x and (b) wouldn't that be a sight? An s390x mainframe in AWS datacenters?
* Rework extensively run scripts to play nice with the various metadata APIs of ECS.
* Throw in support for the agent mode `OFF`.
* Use more idiomatic BASH across the board, to appease to my new best friend [`shellcheck`](https://www.shellcheck.net/).