### PR TITLE
Upgrade to Ubuntu 20:04 to fix automatic attachment of python processes

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Setup of dependencies we need inside the container
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg2 ca-certificates curl && \
-    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables jq && \
+    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python3-pip iptables jq && \
     apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Setup of dependencies we need inside the container
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg2 ca-certificates curl && \
-    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" > /etc/apt/sources.list.d/docker.list && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --fetch-keys "https://download.docker.com/linux/ubuntu/gpg" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python-pip iptables jq && \
+    apt-get install -y --no-install-recommends inotify-tools docker-ce-cli containerd python3-pip iptables jq && \
     apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The pip version we currently ship is too old, version 9.something. This prevents way too many autotrace Python injections from working out of the box when the host agent is deployed via Docker. This change does two things:

1. Upgrade the base image to ubuntu:20.04, which ships python3. While a seemingly drastic change, it seems the best way to deliver `python3`, and it is anyhow long overdue.

2. Change the pip package from `python-pip` to `python3-pip`