### PR TITLE
Use SHORT_SHA to keep image tags concise in cloud builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: '3000s'
 images:
-  - 'gcr.io/$PROJECT_ID/instana-agent-docker:$_FLAVOR-$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/instana-agent-docker:$_FLAVOR-$SHORT_SHA'
 
 substitutions:
   _FLAVOR: 'dynamic'
@@ -16,7 +16,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build -t gcr.io/$PROJECT_ID/instana-agent-docker:$_FLAVOR-$COMMIT_SHA \
+        docker build -t gcr.io/$PROJECT_ID/instana-agent-docker:$_FLAVOR-$SHORT_SHA \
           --no-cache \
           --build-arg FTP_PROXY="$$( cat agent_key.txt )" \
           $_FLAVOR/


### PR DESCRIPTION
* automated builds will use a short hash so they are easier to handle