### PR TITLE
Enable remote initialization of GitOps feature

### DIFF
--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -243,4 +243,4 @@ if [ -f /root/crashReport.sh ] && [ -z "${INSTANA_DISABLE_CRASH_REPORT}" ]; then
 fi
 
 echo "Starting Instana Agent ..."
-exec /opt/instana/agent/bin/karaf daemon
+exec /opt/instana/agent/bin/karaf server

--- a/rhel/run.sh
+++ b/rhel/run.sh
@@ -243,4 +243,4 @@ if [ -f /root/crashReport.sh ] && [ -z "${INSTANA_DISABLE_CRASH_REPORT}" ]; then
 fi
 
 echo "Starting Instana Agent ..."
-exec /opt/instana/agent/bin/karaf daemon
+exec /opt/instana/agent/bin/karaf server

--- a/static/run.sh
+++ b/static/run.sh
@@ -200,4 +200,4 @@ if [ -f /root/crashReport.sh ] && [ -z "${INSTANA_DISABLE_CRASH_REPORT}" ]; then
 fi
 
 echo "Starting Instana Agent ..."
-exec /opt/instana/agent/bin/karaf daemon
+exec /opt/instana/agent/bin/karaf server


### PR DESCRIPTION
Remotely initialising the host agent inside to use the GitOps feature causes its restart.
    
Since we currently start the agent with `/opt/instana/agent/bin/karaf daemon`, the `ENTRYPOINT` of the container terminates when the agent restarts, causing the container to be churned.

This commit changes the initialisation of the agent to `/opt/instana/agent/bin/karaf server`, which will restart the stopping agent, enabling the remote initialisation of the GitOps feature for Docker-based agents.