### PR TITLE
26231 kubernetes agent mode

### DIFF
--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -215,6 +215,8 @@ case "${INSTANA_AGENT_MODE}" in
   'AWS')
     INSTANA_AGENT_MODE='INFRASTRUCTURE'
     ;; # The AWS agent mode is infra + AWS sensor setup
+  'KUBERNETES')
+    ;;
   'INFRASTRUCTURE')
     ;;
   'APM')

--- a/rhel/run.sh
+++ b/rhel/run.sh
@@ -215,6 +215,8 @@ case "${INSTANA_AGENT_MODE}" in
   'AWS')
     INSTANA_AGENT_MODE='INFRASTRUCTURE'
     ;; # The AWS agent mode is infra + AWS sensor setup
+  'KUBERNETES')
+    ;;
   'INFRASTRUCTURE')
     ;;
   'APM')

--- a/static/run.sh
+++ b/static/run.sh
@@ -172,6 +172,8 @@ case "${INSTANA_AGENT_MODE}" in
   'AWS')
     INSTANA_AGENT_MODE='INFRASTRUCTURE'
     ;; # The AWS agent mode is infra + AWS sensor setup
+  'KUBERNETES')
+    ;;
   'INFRASTRUCTURE')
     ;;
   'APM')


### PR DESCRIPTION
Add "kubernetes" as a special agent mode to all docker containers so that we can begin deploying a kubernetes only monitoring agent into kubernetes clusters.

- [kanbanize/26231](https://instana.kanbanize.com/ctrl_board/50/cards/26231/details/)
