### PR TITLE
Adjust docker.sock location for TKGI systems

### DIFF
--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -101,6 +101,18 @@ case ${INSTANA_REPOSITORY_PROXY_ENABLED} in
 	;;
 esac
 
+readonly CANONICAL_DOCKER_SOCKET_PATH='/var/run/docker.sock'
+if [ ! -S "${CANONICAL_DOCKER_SOCKET_PATH}" ]; then
+  echo "Docker socket not found at ${CANONICAL_DOCKER_SOCKET_PATH}"
+
+  readonly KUBO_DOCKER_SOCKET_PATH='/var/vcap/sys/run/docker/docker.sock'
+  if [ -S "${KUBO_DOCKER_SOCKET_PATH}" ]; then
+    # Adjust Docker socket for VMware TKGI and older PKS systems
+    echo "Docker socket found at ${KUBO_DOCKER_SOCKET_PATH}, linking it under ${CANONICAL_DOCKER_SOCKET_PATH}"
+    ln -sf "${KUBO_DOCKER_SOCKET_PATH}" "${CANONICAL_DOCKER_SOCKET_PATH}"
+  fi
+fi
+
 rm -rf /tmp/* /opt/instana/agent/etc/org.ops4j.pax.logging.cfg \
   /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg  \
   /opt/instana/agent/etc/instana/configuration.yaml \

--- a/rhel/run.sh
+++ b/rhel/run.sh
@@ -101,6 +101,19 @@ case ${INSTANA_REPOSITORY_PROXY_ENABLED} in
 	;;
 esac
 
+readonly CANONICAL_DOCKER_SOCKET_PATH='/var/run/docker.sock'
+# Adjust Docker socket for VMware TKGI
+if [ ! -S "${CANONICAL_DOCKER_SOCKET_PATH}" ]; then
+  echo "Docker socket not found at ${CANONICAL_DOCKER_SOCKET_PATH}"
+
+  readonly KUBO_DOCKER_SOCKET_PATH='/var/vcap/sys/run/docker/docker.sock'
+  if [ -S "${KUBO_DOCKER_SOCKET_PATH}" ]; then
+    # Adjust Docker socket for VMware TKGI and older PKS systems
+    echo "Docker socket found at ${KUBO_DOCKER_SOCKET_PATH}, linking it under ${CANONICAL_DOCKER_SOCKET_PATH}"
+    ln -sf "${KUBO_DOCKER_SOCKET_PATH}" "${CANONICAL_DOCKER_SOCKET_PATH}"
+  fi
+fi
+
 rm -rf /tmp/* /opt/instana/agent/etc/org.ops4j.pax.logging.cfg \
   /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg  \
   /opt/instana/agent/etc/instana/configuration.yaml \

--- a/static/run.sh
+++ b/static/run.sh
@@ -62,6 +62,19 @@ if [ -n "${INSTANA_AGENT_PROXY_USE_DNS}" ]; then
   esac
 fi
 
+readonly CANONICAL_DOCKER_SOCKET_PATH='/var/run/docker.sock'
+# Adjust Docker socket for VMware TKGI
+if [ ! -S "${CANONICAL_DOCKER_SOCKET_PATH}" ]; then
+  echo "Docker socket not found at ${CANONICAL_DOCKER_SOCKET_PATH}"
+
+  readonly KUBO_DOCKER_SOCKET_PATH='/var/vcap/sys/run/docker/docker.sock'
+  if [ -S "${KUBO_DOCKER_SOCKET_PATH}" ]; then
+    # Adjust Docker socket for VMware TKGI and older PKS systems
+    echo "Docker socket found at ${KUBO_DOCKER_SOCKET_PATH}, linking it under ${CANONICAL_DOCKER_SOCKET_PATH}"
+    ln -sf "${KUBO_DOCKER_SOCKET_PATH}" "${CANONICAL_DOCKER_SOCKET_PATH}"
+  fi
+fi
+
 rm -rf /tmp/* /opt/instana/agent/etc/org.ops4j.pax.logging.cfg \
   /opt/instana/agent/etc/org.ops4j.pax.url.mvn.cfg  \
   /opt/instana/agent/etc/instana/configuration.yaml \


### PR DESCRIPTION
On VMware Tanzu TKGI (formerly known as PKS) systems, the Docker socket is mounted at `/var/vcap/sys/run/docker/docker.sock` rather than the canonical `/var/run/docker.sock` (see [this issue](https://github.com/cloudfoundry-incubator/kubo-release/issues/329)). This patch adjusts the mounting location of the Docker socket inside the container as the container starts, provided that `/var/vcap/sys/run/docker` is mounted (which will need an accompanying patch in Helm charts and YAML).