### PR TITLE
Disable root account for Ubuntu images - CVE-2019-5021

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -65,7 +65,8 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /etc/apt/sources.list.d/instana-agent.list && \
     rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
+    apt-get clean && \
+    sed -i -e 's/^root:[^:]*:/root:!locked:/' /etc/shadow
 
 COPY org.ops4j.pax.logging.cfg.tmpl \
     org.ops4j.pax.url.mvn.cfg.tmpl \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -51,7 +51,8 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /etc/apt/sources.list.d/instana-agent.list && \
     rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
+    apt-get clean && \
+    sed -i -e 's/^root:[^:]*:/root:!locked:/' /etc/shadow
 
 COPY org.ops4j.pax.logging.cfg.tmpl \
     configuration.yaml \

--- a/static/Dockerfile.s390x
+++ b/static/Dockerfile.s390x
@@ -36,7 +36,8 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /etc/apt/sources.list.d/instana-agent.list && \
     rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
+    apt-get clean && \
+    sed -i -e 's/^root:[^:]*:/root:!locked:/' /etc/shadow
 
 ADD org.ops4j.pax.logging.cfg /root/
 ADD configuration.yaml /root/


### PR DESCRIPTION
Circumvents the issue as outlined in https://nvd.nist.gov/vuln/detail/CVE-2019-5021, which is the originator for Instana Agent CVE https://nvd.nist.gov/vuln/detail/CVE-2020-35463.

Bottom-line doesn't matter much, because our container is running as privileged, Agent process running as `root` and we don't expose any other services (that following the CVE could result in elevated privileges).
But since the change is small and has no negative impact, would take away the basis for the CVE. Also gives the same result as RHEL already has:

```sh
[root@codepaper agent]# cat /etc/shadow
root:!locked::0:99999:7:::
```

(basically applies the fix as mentioned here: https://alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html)

