### PR TITLE
Copy licenses instead of symlinking, to fix RHEL container validation

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -36,6 +36,7 @@ RUN curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     [[ -z "${FTP_PROXY}" ]] || DOWNLOAD_KEY="${FTP_PROXY}" && \
     echo -e "[instana-agent]\nname=Instana\nbaseurl=https://_:${DOWNLOAD_KEY}@packages.instana.io/agent/generic/${arch}\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.instana.io/Instana.gpg\nsslverify=1" > /etc/yum.repos.d/Instana-Agent.repo && \
     microdnf install instana-agent-dynamic && \
+    mv /opt/instana/agent/licenses /licenses && \
     rm -rf /tmp/* /etc/yum.repos.d/Instana-Agent.repo && \
     microdnf clean all
 
@@ -105,10 +106,8 @@ ADD help.1 /help.1
 
 # Configuration up to this line needs to be in sync with static/Dockerfile
 COPY --from=instana-agent /opt/instana /opt/instana
+COPY --from=instana-agent /licenses /licenses
 COPY --from=instana-agent /usr/lib/tmpfiles.d/instana-agent.conf /usr/lib/tmpfiles.d/instana-agent.conf
-
-RUN mkdir /licenses \
-    && cp -r /opt/instana/agent/licenses/* /licenses/
 
 ENV LANG=C.UTF-8 \
     INSTANA_AGENT_KEY="" \

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -107,7 +107,8 @@ ADD help.1 /help.1
 COPY --from=instana-agent /opt/instana /opt/instana
 COPY --from=instana-agent /usr/lib/tmpfiles.d/instana-agent.conf /usr/lib/tmpfiles.d/instana-agent.conf
 
-RUN ln -s /opt/instana/agent/licenses /licenses
+RUN mkdir /licenses \
+    && cp -r /opt/instana/agent/licenses/* /licenses/
 
 ENV LANG=C.UTF-8 \
     INSTANA_AGENT_KEY="" \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -107,7 +107,9 @@ ADD help.1 /help.1
 COPY --from=instana-agent /opt/instana /opt/instana
 COPY --from=instana-agent /usr/lib/tmpfiles.d/instana-agent.conf /usr/lib/tmpfiles.d/instana-agent.conf
 
-RUN ln -s /opt/instana/agent/licenses /licenses
+RUN mkdir /licenses \
+    && cp -r /opt/instana/agent/licenses/* /licenses/
+
 
 ENV LANG=C.UTF-8 \
     INSTANA_AGENT_KEY="" \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -36,6 +36,7 @@ RUN curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     [[ -z "${FTP_PROXY}" ]] || DOWNLOAD_KEY="${FTP_PROXY}" && \
     echo -e "[instana-agent]\nname=Instana\nbaseurl=https://_:${DOWNLOAD_KEY}@packages.instana.io/agent/generic/${arch}\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.instana.io/Instana.gpg\nsslverify=1" > /etc/yum.repos.d/Instana-Agent.repo && \
     microdnf install instana-agent-static && \
+    mv /opt/instana/agent/licenses /licenses && \
     rm -rf /tmp/* /etc/yum.repos.d/Instana-Agent.repo && \
     microdnf clean all
 
@@ -105,11 +106,8 @@ ADD help.1 /help.1
 
 # Configuration up to this line needs to be in sync with static/Dockerfile
 COPY --from=instana-agent /opt/instana /opt/instana
+COPY --from=instana-agent /licenses /licenses
 COPY --from=instana-agent /usr/lib/tmpfiles.d/instana-agent.conf /usr/lib/tmpfiles.d/instana-agent.conf
-
-RUN mkdir /licenses \
-    && cp -r /opt/instana/agent/licenses/* /licenses/
-
 
 ENV LANG=C.UTF-8 \
     INSTANA_AGENT_KEY="" \


### PR DESCRIPTION
With the change to UBI images, the "has_licenses" check fails on the RHEL container registry.

Description states:

> Test name: has_licenses
> Why? So the end user is aware of the terms and conditions applicable to the software. Including opens source licensing information, if open source components are included in the image.
> How? Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.

Expectation is that the symlink is not sufficient, so create a hard copy instead.