### PR TITLE
Remove JAVA_OPTS settings

### DIFF
--- a/dynamic/run.sh
+++ b/dynamic/run.sh
@@ -254,8 +254,5 @@ if [ -d /host/proc ]; then
   export INSTANA_AGENT_PROC_PATH=/host/proc
 fi
 
-# Approximately 1/3 of container memory requests to allow for direct-buffer memory usage and JVM overhead
-echo "export JAVA_OPTS=\"-XX:+UseContainerSupport -XX:MaxRAMFraction=3 -XX:+ExitOnOutOfMemoryError ${JAVA_OPTS}\"" >> /opt/instana/agent/bin/setenv
-
 echo "Starting Instana Agent ..."
 exec /opt/instana/agent/bin/karaf server

--- a/static/run.sh
+++ b/static/run.sh
@@ -218,8 +218,5 @@ if [ -d /host/proc ]; then
   export INSTANA_AGENT_PROC_PATH=/host/proc
 fi
 
-# Approximately 1/3 of container memory requests to allow for direct-buffer memory usage and JVM overhead
-echo "export JAVA_OPTS=\"-XX:+UseContainerSupport -XX:MaxRAMFraction=3 -XX:+ExitOnOutOfMemoryError ${JAVA_OPTS}\"" >> /opt/instana/agent/bin/setenv
-
 echo "Starting Instana Agent ..."
 exec /opt/instana/agent/bin/karaf server


### PR DESCRIPTION
Now that Memory Calculator is available in the upstream RPM package, remove the provisional `JAVA_OPTS` setting that was activating `-XX:+UseContainerSupport`.