### PR TITLE
Update pipeline to download and use instana-twistcli 0.0.10

### DIFF
--- a/ci/copy-scan-image-file-task.yml
+++ b/ci/copy-scan-image-file-task.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: ubuntu
+    tag: 20.04
+inputs:
+  - name: instana-twistcli-build-artifacts
+outputs:
+  - name: scan-image-file
+run:
+  path: bash
+  args:
+    - -o
+    - errexit
+    - -c
+    - |
+      mkdir -p instana-twistcli
+      tar xfz instana-twistcli-build-artifacts/instana-twistcli-((instana-twistcli-version)).tar.gz -C instana-twistcli --strip-components=1
+      cp instana-twistcli/scan-image.yml scan-image-file

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,5 +1,12 @@
 ---
 # see https://concourse-ci.org/pipelines.html
+
+var_sources:
+  - name: local-vars
+    type: dummy
+    config:
+      vars:
+        instana-twistcli-version: '0.0.10'
 resource_types:
   - name: codebuild
     type: registry-image
@@ -304,19 +311,15 @@ resources:
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
 
-  - name: internal-tools
-    type: git
-    icon: github
+  - name: instana-twistcli-build-artifacts
+    type: s3
+    icon: zip-disk
     source:
-      uri: https://github.com/instana/internal-tools.git
-      username: ((instanacd-github-api-token))
-      password: x-oauth-basic
-      branch: master
-      paths:
-      - ci-utility-images/instana-twistcli
-      ignore_paths:
-      - ci-utility-images/instana-twistcli/README.md
-      - ci-utility-images/instana-twistcli/VERSION
+      bucket: instana-twistcli-build-artifacts
+      versioned_file: instana-twistcli-((local-vars:instana-twistcli-version)).tar.gz
+      access_key_id: ((codebuild-s3-user-devinfra-key.key_id))
+      secret_access_key: ((codebuild-s3-user-devinfra-key.key_secret))
+      region_name: us-west-2
 
 jobs:
   - name: bump-release-version
@@ -654,7 +657,6 @@ jobs:
         passed: [amd64-build]
       - get: agent-version
         trigger: true
-      - get: internal-tools
 
       - load_var: digest-amd64
         file: agent-static-amd64/digest
@@ -663,18 +665,22 @@ jobs:
       - load_var: agent-version
         file: agent-version/number
         reveal: true
+      - task: copy-scan-image-file
+        file: instana-agent-docker-git/ci/copy-scan-image-file-task.yml
+        vars:
+          instana-twistcli-version: ((local-vars:instana-twistcli-version))
 
       - in_parallel:
           steps:
           - task: scan-image-amd64-static
             privileged: true
-            file: internal-tools/ci-utility-images/instana-twistcli/ci/tasks/scan-image.yml
+            file: scan-image-file/scan-image.yml
             vars:
               target-image: gcr.io/instana-agent-qa/instana-agent-docker@((.:digest-amd64))
               docker-json-key: ((project-berlin-tests-gcp-instana-qa))
           - task: scan-image-amd64-j9-static
             privileged: true
-            file: internal-tools/ci-utility-images/instana-twistcli/ci/tasks/scan-image.yml
+            file: scan-image-file/scan-image.yml
             vars:
               target-image: gcr.io/instana-agent-qa/instana-agent-docker@((.:digest-amd64-j9))
               docker-json-key: ((project-berlin-tests-gcp-instana-qa))


### PR DESCRIPTION
# Why

- New version of `instana-twistcli` [released](https://github.com/instana/internal-tools/blob/master/ci-utility-images/instana-twistcli/CHANGELOG.md) containing an updated version of `twistcli`
- We should pin the version of the `scan-image.yml` task file to the version of `instana-twistcli` as there will be breaking changes incoming soon if we just use the latest `scan-image.yml` file from `internal-tools/master`

# What

- Download v0.0.10 of `instana-twistcli` from the `instana-twistcli-build-artifacts` S3 bucket
- Use the `scan-image.yml` task file from the aforementioned downloaded version of `instana-twistcli`

# References

- https://instana.kanbanize.com/ctrl_board/75/cards/67611/details/
- https://github.com/instana/internal-tools/pull/75