### PR TITLE
Enable P support in dockerfiles and Concourse CI

### DIFF
--- a/ci/create-multiarch-image-task.yml
+++ b/ci/create-multiarch-image-task.yml
@@ -37,6 +37,8 @@ run:
       # Here we fix it in case only 'j9' is given.
       # Empty CLASSIFIER means classic OpenJDK based images.
 
+      # NOTE: for s390x, ppc64le J9 is the default runtime, RPM/DEB packages for s390x, ppc64le with Azul 8 Java are unavailable
+
       # CLASSIFIER is not empty and does not start with a '-':
       if [ "${CLASSIFIER}x" != 'x' ] && [ "${CLASSIFIER#-}" = "${CLASSIFIER}" ]; then
         CLASSIFIER="-${CLASSIFIER}"
@@ -46,16 +48,19 @@ run:
       docker pull "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-amd64-$FLAVOR$CLASSIFIER"
       docker pull "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-s390x-$FLAVOR"
       docker pull "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-arm64-$FLAVOR$CLASSIFIER"
+      docker pull "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-ppc64le-$FLAVOR"
 
       docker pull "gcr.io/instana-agent-qa/instana-agent-docker:latest-amd64-$FLAVOR$CLASSIFIER"
       docker pull "gcr.io/instana-agent-qa/instana-agent-docker:latest-s390x-$FLAVOR"
       docker pull "gcr.io/instana-agent-qa/instana-agent-docker:latest-arm64-$FLAVOR$CLASSIFIER"
+      docker pull "gcr.io/instana-agent-qa/instana-agent-docker:latest-ppc64le-$FLAVOR"
 
       echo "---> Building multi-architectural manifest"
       docker manifest create "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-$FLAVOR$CLASSIFIER" \
         --amend "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-amd64-$FLAVOR$CLASSIFIER" \
         --amend "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-s390x-$FLAVOR" \
-        --amend "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-arm64-$FLAVOR$CLASSIFIER"
+        --amend "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-arm64-$FLAVOR$CLASSIFIER" \
+        --amend "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-ppc64le-$FLAVOR"
 
       echo "---> Pushing multi-architectural manifest"
       docker manifest push "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-$FLAVOR$CLASSIFIER"
@@ -67,17 +72,21 @@ run:
         "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-s390x"
       docker tag "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-arm64-$FLAVOR$CLASSIFIER" \
         "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-arm64"
+      docker tag "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-ppc64le-$FLAVOR" \
+        "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-ppc64le"
 
       echo "Pushing containers to containers.instana.io"
       docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-amd64"
       docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-s390x"
       docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-arm64"
+      docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-ppc64le"
 
       echo "Creating multi-architectural manifest for containers.instana.io"
       docker manifest create "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER" \
         --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-amd64" \
         --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-s390x" \
-        --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-arm64"
+        --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-arm64" \
+        --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-ppc64le"
 
       echo "---> Pushing multi-architectural image to containers.instana.io"
       docker manifest push "containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER"
@@ -89,17 +98,21 @@ run:
         "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-s390x"
       docker tag "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-arm64-$FLAVOR$CLASSIFIER" \
         "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-arm64"
+      docker tag "gcr.io/instana-agent-qa/instana-agent-docker:$COMMIT_SHA-ppc64le-$FLAVOR" \
+        "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-ppc64le"
 
       echo "---> Pushing latest containers to containers.instana.io"
       docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-amd64"
       docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-s390x"
       docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-arm64"
+      docker push "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-ppc64le"
 
       echo "---> Creating multi-architectural latest manifest containers.instana.io"
       docker manifest create "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER" \
         --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-amd64" \
         --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-s390x" \
-        --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-arm64"
+        --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-arm64" \
+        --amend "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-ppc64le"
 
       echo "---> Pushing latest manifest to containers.instana.io"
       docker manifest push "containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER"
@@ -109,10 +122,12 @@ run:
       containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-amd64
       containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-s390x
       containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER-arm64
+      containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION-ppc64le
       containers.instana.io/instana/prerelease/agent/$FLAVOR:$VERSION$CLASSIFIER
 
       containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-amd64
       containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-s390x
       containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER-arm64
+      containers.instana.io/instana/prerelease/agent/$FLAVOR:latest-ppc64le
       containers.instana.io/instana/prerelease/agent/$FLAVOR:latest$CLASSIFIER
       EOF

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -22,11 +22,13 @@ RUN microdnf install tar gzip wget golang make findutils socat && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o gomplate_amd64 ./cmd/gomplate && \
     GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o gomplate_arm64 ./cmd/gomplate && \
     GOOS=linux GOARCH=s390x CGO_ENABLED=0 go build -o gomplate_s390x ./cmd/gomplate && \
-    mkdir -p /usr/bin/linux/{amd64,arm64,s390x} && \
+    GOOS=linux GOARCH=ppc64le CGO_ENABLED=0 go build -o gomplate_ppc64le ./cmd/gomplate && \
+    mkdir -p /usr/bin/linux/{amd64,arm64,s390x,ppc64le} && \
     chmod u+x gomplate_* && \
     cp gomplate_amd64 /usr/bin/linux/amd64/gomplate && \
     cp gomplate_arm64 /usr/bin/linux/arm64/gomplate && \
-    cp gomplate_s390x /usr/bin/linux/s390x/gomplate
+    cp gomplate_s390x /usr/bin/linux/s390x/gomplate && \
+    cp gomplate_ppc64le /usr/bin/linux/ppc64le/gomplate
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS instana-agent
 
@@ -38,9 +40,9 @@ ARG FTP_PROXY
 
 RUN curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     rpm --import /tmp/Instana.gpg && \
-    export arch=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'x86_64' ;; 'linux/arm64') echo 'aarch64' ;; 'linux/s390x') echo 's390x' ;; esac) && \
+    export arch=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'x86_64' ;; 'linux/arm64') echo 'aarch64' ;; 'linux/s390x') echo 's390x' ;; 'linux/ppc64le') echo 'ppc64le' ;; esac) && \
     [[ -z "${FTP_PROXY}" ]] || DOWNLOAD_KEY="${FTP_PROXY}" && \
-    [[ "${arch}" != "s390x" ]] || CLASSIFIER="-j9" && \
+    [[ "${arch}" != "s390x" && "${arch}" != "ppc64le" ]] || CLASSIFIER="-j9" && \
     [[ "${CLASSIFIER}x" = "x" ]] || [[ "${CLASSIFIER#-}" != "${CLASSIFIER}" ]] || CLASSIFIER="-${CLASSIFIER}" && \
     echo -e "[instana-agent]\nname=Instana\nbaseurl=https://_:${DOWNLOAD_KEY}@packages.instana.io/agent/generic/${arch}\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.instana.io/Instana.gpg\nsslverify=1" > /etc/yum.repos.d/Instana-Agent.repo && \
     microdnf install "instana-agent-dynamic${CLASSIFIER}" && \
@@ -70,8 +72,8 @@ RUN pip3 install pip==20.3.4
 # !! NOTE: the following sections contain inverse IF-statements to make sure commands succeed
 # when not applicable but breaks when any command fails. The regular " IF ... && <command> || true " won't work.
 
-# s390x does not carry the Docker cli (and neither do RHEL official repositories)
-RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' ]] || ( \
+# s390x and ppc64le do not carry the Docker cli (and neither do RHEL official repositories)
+RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' || "${TARGETPLATFORM}" = 'linux/ppc64le' ]] || ( \
         echo -e '[docker-ce-stable]\nname=Docker CE Stable - $basearch\nbaseurl=https://download.docker.com/linux/centos/8/$basearch/stable\nenabled=1\ngpgcheck=1\ngpgkey=https://download.docker.com/linux/centos/gpg' > /etc/yum.repos.d/docker.repo \
         && microdnf install --nodocs docker-ce-cli \
         && rm -rf /tmp/* /etc/yum.repos.d/docker.repo \
@@ -90,10 +92,22 @@ RUN [[ "${TARGETPLATFORM}" != 'linux/amd64' ]] || ( \
         && rm -rf /tmp/* \
     )
 
-# On s390x install docker ce, runc and containerd from docker static s390x build
+# On s390x, install docker ce, runc and containerd from docker static s390x build
 RUN [[ "${TARGETPLATFORM}" != 'linux/s390x' ]] || ( \
         cd /tmp \
         && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
+        && gunzip docker-18.06.3-ce.tgz \
+        && tar -xvf docker-18.06.3-ce.tar \
+        && mv docker/docker /usr/local/bin/docker \
+        && mv docker/docker-containerd /usr/local/bin/containerd \
+        && mv docker/docker-containerd-shim /usr/local/bin/containerd-shim \
+        && rm -rf /tmp/* \
+    )
+
+# On ppc64le, install docker ce, runc and containerd from docker static ppc64le build
+RUN [[ "${TARGETPLATFORM}" != 'linux/ppc64le' ]] || ( \
+        cd /tmp \
+        && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/ppc64le/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
         && gunzip docker-18.06.3-ce.tgz \
         && tar -xvf docker-18.06.3-ce.tar \
         && mv docker/docker /usr/local/bin/docker \
@@ -133,9 +147,21 @@ RUN [[ "${TARGETPLATFORM}" != 'linux/s390x' ]] || ( \
         && microdnf clean all \
     )
 
+# Install iptables 1.4.21 on ppc64le to carry out service mesh bypass scripts.
+ENV IPTABLES_PPC64LE_SHA256="1eb70870bd717d010127a0d6a6bd61d1e621120b770d7c9e9bde125b08d9bd71  iptables-1.4.21-35.el7.ppc64le.rpm"
+RUN [[ "${TARGETPLATFORM}" != 'linux/ppc64le' ]] || ( \
+        microdnf install libnetfilter_conntrack \
+        && cd /tmp \
+        && curl -L --fail --show-error --silent http://mirror.centos.org/altarch/7/os/ppc64le/Packages/iptables-1.4.21-35.el7.ppc64le.rpm -o /tmp/iptables-1.4.21-35.el7.ppc64le.rpm \
+        && echo "${IPTABLES_PPC64LE_SHA256}" | sha256sum --check > /dev/null \
+        && rpm -i /tmp/iptables-1.4.21-35.el7.ppc64le.rpm \
+        && rm -rf /tmp/* \
+        && microdnf clean all \
+    )
+
 # Install Tini, to handle signals (SIGTERM / SIGKILL) correctly in our container since we need to run the Agent from a
 # script and cannot 'exec' to replace it. That would kill the container on restarts of the Agent.
-RUN export ARCH=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'amd64' ;; 'linux/arm64') echo 'arm64' ;; 'linux/s390x') echo 's390x' ;; esac) \
+RUN export ARCH=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'amd64' ;; 'linux/arm64') echo 'arm64' ;; 'linux/s390x') echo 's390x' ;; 'linux/ppc64le') echo 'ppc64le' ;; esac) \
     && export TINI_VERSION=$(curl -L -s -H 'Accept: application/json' https://github.com/krallin/tini/releases/latest | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/') \
     && cd /tmp \
     && curl -L --fail --show-error --silent https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${ARCH} -o tini-${ARCH} \

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -137,6 +137,20 @@ resources:
       json_key: ((gcloud-agent-ci-account-key))
       regexp: packages/instana-agent-dynamic-j9-(2.*)\.s390x\.rpm
 
+  ## ppc64le packages
+  - name: rpm-static-ppc64le-j9
+    type: gcs-resource
+    source:
+      bucket: agent-ci
+      json_key: ((gcloud-agent-ci-account-key))
+      regexp: packages/instana-agent-static-j9-(2.*)\.ppc64le\.rpm
+  - name: rpm-dynamic-ppc64le-j9
+    type: gcs-resource
+    source:
+      bucket: agent-ci
+      json_key: ((gcloud-agent-ci-account-key))
+      regexp: packages/instana-agent-dynamic-j9-(2.*)\.ppc64le\.rpm
+
   - name: build-bundle
     type: s3
     icon: zip-disk
@@ -231,6 +245,23 @@ resources:
       access_key_id: ((codebuild-key.key_id))
       secret_access_key: ((codebuild-key.key_secret))
 
+  - name: codebuild-dynamic-ppc64le
+    type: codebuild
+    icon: aws
+    source:
+      project: instana-agent-images-s390x
+      region: us-west-2
+      access_key_id: ((codebuild-key.key_id))
+      secret_access_key: ((codebuild-key.key_secret))
+  - name: codebuild-static-ppc64le
+    type: codebuild
+    icon: aws
+    source:
+      project: instana-agent-images-s390x
+      region: us-west-2
+      access_key_id: ((codebuild-key.key_id))
+      secret_access_key: ((codebuild-key.key_secret))
+
   - name: agent-dynamic-arm64
     type: registry-image
     icon: docker
@@ -315,6 +346,23 @@ resources:
       username: _json_key
       password: ((project-berlin-tests-gcp-instana-qa))
 
+  - name: agent-dynamic-ppc64le
+    type: registry-image
+    icon: docker
+    source:
+      repository: gcr.io/instana-agent-qa/instana-agent-docker
+      tag: latest-ppc64le-dynamic
+      username: _json_key
+      password: ((project-berlin-tests-gcp-instana-qa))
+  - name: agent-static-ppc64le
+    type: registry-image
+    icon: docker
+    source:
+      repository: gcr.io/instana-agent-qa/instana-agent-docker
+      tag: latest-ppc64le-static
+      username: _json_key
+      password: ((project-berlin-tests-gcp-instana-qa))
+
   - name: instana-twistcli-build-artifacts
     type: s3
     icon: zip-disk
@@ -373,6 +421,10 @@ jobs:
       - get: rpm-static-s390x-j9
         trigger: true
       - get: rpm-dynamic-s390x-j9
+        trigger: true
+      - get: rpm-static-ppc64le-j9
+        trigger: true
+      - get: rpm-dynamic-ppc64le-j9
         trigger: true
       - put: agent-version
         params: { bump: patch }
@@ -650,6 +702,67 @@ jobs:
                   image: codebuild-static-s390x/artifacts/image.tar
                   additional_tags: codebuild-static-s390x/artifacts/tag
 
+  - name: ppc64le-build
+    max_in_flight: 1
+    public: true
+    plan:
+      - get: instana-agent-docker-git
+        trigger: true
+        passed: [ prepare-build-bundle ]
+      - get: build-bundle
+        trigger: true
+        passed: [ prepare-build-bundle ]
+      - get: agent-version
+        passed: [ prepare-build-bundle ]
+        trigger: true
+      - load_var: agent-version
+        file: agent-version/number
+        reveal: true
+      - load_var: s3-artifact-version
+        file: build-bundle/version
+        reveal: true
+      - load_var: commit-sha
+        file: instana-agent-docker-git/.git/short_ref
+        reveal: true
+      - in_parallel:
+          fail_fast: true
+          steps:
+            - put: codebuild-static-ppc64le
+              params:
+                source_version: ((.:s3-artifact-version))
+                env_var_overrides:
+                  ARCH: ppc64le
+                  DOWNLOAD_KEY: ((qa-instana-agent-key))
+                  FLAVOR: static
+                  CLASSIFIER: ''
+                  VERSION: ((.:agent-version))
+                  BRANCH: ((.:commit-sha))
+                  COMMIT_SHA: ((.:commit-sha))
+                  TARGETPLATFORM: linux/ppc64le
+            - put: codebuild-dynamic-ppc64le
+              params:
+                source_version: ((.:s3-artifact-version))
+                env_var_overrides:
+                  ARCH: ppc64le
+                  DOWNLOAD_KEY: ((qa-instana-agent-key))
+                  FLAVOR: dynamic
+                  CLASSIFIER: ''
+                  VERSION: ((.:agent-version))
+                  BRANCH: ((.:commit-sha))
+                  COMMIT_SHA: ((.:commit-sha))
+                  TARGETPLATFORM: linux/ppc64le
+      - in_parallel:
+          fail_fast: true
+          steps:
+            - put: agent-dynamic-ppc64le
+              params:
+                  image: codebuild-dynamic-ppc64le/artifacts/image.tar
+                  additional_tags: codebuild-dynamic-ppc64le/artifacts/tag
+            - put: agent-static-ppc64le
+              params:
+                  image: codebuild-static-ppc64le/artifacts/image.tar
+                  additional_tags: codebuild-static-ppc64le/artifacts/tag
+
   - name: twistlock-security-scan
     max_in_flight: 1
     plan:
@@ -883,10 +996,10 @@ jobs:
     plan:
       - get: instana-agent-docker-git
         trigger: true
-        passed: [ s390x-build, arm64-build, amd64-build ]
+        passed: [ ppc64le-build, s390x-build, arm64-build, amd64-build ]
       - get: agent-version
         trigger: true
-        passed: [ s390x-build, arm64-build, amd64-build, twistlock-security-scan ]
+        passed: [ ppc64le-build, s390x-build, arm64-build, amd64-build, twistlock-security-scan ]
 
       - get: agent-dynamic-amd64
         params:
@@ -905,6 +1018,9 @@ jobs:
       - get: agent-dynamic-s390x
         params:
           skip_download: true
+      - get: agent-dynamic-ppc64le
+        params:
+          skip_download: true
 
       - get: agent-static-amd64
         params:
@@ -921,6 +1037,9 @@ jobs:
         params:
           skip_download: true
       - get: agent-static-s390x
+        params:
+          skip_download: true
+      - get: agent-static-ppc64le
         params:
           skip_download: true
 
@@ -943,6 +1062,10 @@ jobs:
           skip_download: true
         passed: [ verification-gate ]
       - get: agent-dynamic-arm64
+        params:
+          skip_download: true
+        passed: [ verification-gate ]
+      - get: agent-dynamic-ppc64le
         params:
           skip_download: true
         passed: [ verification-gate ]
@@ -1033,6 +1156,10 @@ jobs:
           skip_download: true
         passed: [ verification-gate ]
       - get: agent-static-s390x
+        params:
+          skip_download: true
+        passed: [ verification-gate ]
+      - get: agent-static-ppc64le
         params:
           skip_download: true
         passed: [ verification-gate ]

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -22,11 +22,13 @@ RUN microdnf install tar gzip wget golang make findutils socat && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o gomplate_amd64 ./cmd/gomplate && \
     GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o gomplate_arm64 ./cmd/gomplate && \
     GOOS=linux GOARCH=s390x CGO_ENABLED=0 go build -o gomplate_s390x ./cmd/gomplate && \
-    mkdir -p /usr/bin/linux/{amd64,arm64,s390x} && \
+    GOOS=linux GOARCH=ppc64le CGO_ENABLED=0 go build -o gomplate_ppc64le ./cmd/gomplate && \
+    mkdir -p /usr/bin/linux/{amd64,arm64,s390x,ppc64le} && \
     chmod u+x gomplate_* && \
     cp gomplate_amd64 /usr/bin/linux/amd64/gomplate && \
     cp gomplate_arm64 /usr/bin/linux/arm64/gomplate && \
-    cp gomplate_s390x /usr/bin/linux/s390x/gomplate
+    cp gomplate_s390x /usr/bin/linux/s390x/gomplate && \
+    cp gomplate_ppc64le /usr/bin/linux/ppc64le/gomplate
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS instana-agent
 
@@ -38,9 +40,9 @@ ARG FTP_PROXY
 
 RUN curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     rpm --import /tmp/Instana.gpg && \
-    export arch=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'x86_64' ;; 'linux/arm64') echo 'aarch64' ;; 'linux/s390x') echo 's390x' ;; esac) && \
+    export arch=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'x86_64' ;; 'linux/arm64') echo 'aarch64' ;; 'linux/s390x') echo 's390x' ;; 'linux/ppc64le') echo 'ppc64le' ;; esac) && \
     [[ -z "${FTP_PROXY}" ]] || DOWNLOAD_KEY="${FTP_PROXY}" && \
-    [[ "${arch}" != "s390x" ]] || CLASSIFIER="-j9" && \
+    [[ "${arch}" != "s390x" && "${arch}" != "ppc64le" ]] || CLASSIFIER="-j9" && \
     [[ "${CLASSIFIER}x" = "x" ]] || [[ "${CLASSIFIER#-}" != "${CLASSIFIER}" ]] || CLASSIFIER="-${CLASSIFIER}" && \
     echo -e "[instana-agent]\nname=Instana\nbaseurl=https://_:${DOWNLOAD_KEY}@packages.instana.io/agent/generic/${arch}\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.instana.io/Instana.gpg\nsslverify=1" > /etc/yum.repos.d/Instana-Agent.repo && \
     microdnf install "instana-agent-static${CLASSIFIER}" && \
@@ -70,8 +72,8 @@ RUN pip3 install pip==20.3.4
 # !! NOTE: the following sections contain inverse IF-statements to make sure commands succeed
 # when not applicable but breaks when any command fails. The regular " IF ... && <command> || true " won't work.
 
-# s390x does not carry the Docker cli (and neither do RHEL official repositories)
-RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' ]] || ( \
+# s390x and ppc64le do not carry the Docker cli (and neither do RHEL official repositories)
+RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' || "${TARGETPLATFORM}" = 'linux/ppc64le' ]] || ( \
         echo -e '[docker-ce-stable]\nname=Docker CE Stable - $basearch\nbaseurl=https://download.docker.com/linux/centos/8/$basearch/stable\nenabled=1\ngpgcheck=1\ngpgkey=https://download.docker.com/linux/centos/gpg' > /etc/yum.repos.d/docker.repo \
         && microdnf install --nodocs docker-ce-cli \
         && rm -rf /tmp/* /etc/yum.repos.d/docker.repo \
@@ -94,6 +96,18 @@ RUN [[ "${TARGETPLATFORM}" != 'linux/amd64' ]] || ( \
 RUN [[ "${TARGETPLATFORM}" != 'linux/s390x' ]] || ( \
         cd /tmp \
         && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
+        && gunzip docker-18.06.3-ce.tgz \
+        && tar -xvf docker-18.06.3-ce.tar \
+        && mv docker/docker /usr/local/bin/docker \
+        && mv docker/docker-containerd /usr/local/bin/containerd \
+        && mv docker/docker-containerd-shim /usr/local/bin/containerd-shim \
+        && rm -rf /tmp/* \
+    )
+
+# On ppc64le, install docker ce, runc and containerd from docker static ppc64le build
+RUN [[ "${TARGETPLATFORM}" != 'linux/ppc64le' ]] || ( \
+        cd /tmp \
+        && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/ppc64le/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
         && gunzip docker-18.06.3-ce.tgz \
         && tar -xvf docker-18.06.3-ce.tar \
         && mv docker/docker /usr/local/bin/docker \
@@ -133,9 +147,21 @@ RUN [[ "${TARGETPLATFORM}" != 'linux/s390x' ]] || ( \
         && microdnf clean all \
     )
 
+# Install iptables 1.4.21 on ppc64le to carry out service mesh bypass scripts.
+ENV IPTABLES_PPC64LE_SHA256="1eb70870bd717d010127a0d6a6bd61d1e621120b770d7c9e9bde125b08d9bd71  iptables-1.4.21-35.el7.ppc64le.rpm"
+RUN [[ "${TARGETPLATFORM}" != 'linux/ppc64le' ]] || ( \
+        microdnf install libnetfilter_conntrack \
+        && cd /tmp \
+        && curl -L --fail --show-error --silent http://mirror.centos.org/altarch/7/os/ppc64le/Packages/iptables-1.4.21-35.el7.ppc64le.rpm -o /tmp/iptables-1.4.21-35.el7.ppc64le.rpm \
+        && echo "${IPTABLES_PPC64LE_SHA256}" | sha256sum --check > /dev/null \
+        && rpm -i /tmp/iptables-1.4.21-35.el7.ppc64le.rpm \
+        && rm -rf /tmp/* \
+        && microdnf clean all \
+    )
+
 # Install Tini, to handle signals (SIGTERM / SIGKILL) correctly in our container since we need to run the Agent from a
 # script and cannot 'exec' to replace it. That would kill the container on restarts of the Agent.
-RUN export ARCH=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'amd64' ;; 'linux/arm64') echo 'arm64' ;; 'linux/s390x') echo 's390x' ;; esac) \
+RUN export ARCH=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'amd64' ;; 'linux/arm64') echo 'arm64' ;; 'linux/s390x') echo 's390x' ;; 'linux/ppc64le') echo 'ppc64le' ;; esac) \
     && export TINI_VERSION=$(curl -L -s -H 'Accept: application/json' https://github.com/krallin/tini/releases/latest | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/') \
     && cd /tmp \
     && curl -L --fail --show-error --silent https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${ARCH} -o tini-${ARCH} \


### PR DESCRIPTION
This PR adds Power (ppc64le) support to the dockefiles as well as Concourse CI pipeline. Test build: [plinux-agent](https://ci.instana.io/teams/agent/pipelines/plinux-agent)

The image pushed by the CI to GCR has been validated on ppc64le by making sure that the pod comes up properly on minikube cluster. Logs below.

```
# kubectl get pods -A
NAMESPACE       NAME                                      READY   STATUS             RESTARTS   AGE
instana-agent   instana-agent-operator-6b596f8d67-6mfcb   1/1     Running            0          131m
instana-agent   instana-agent-v29bg                       1/1     Running            0          7s
kube-system     coredns-f9fd979d6-rjvm8                   1/1     Running            0          54d
kube-system     etcd-p006vm71                             1/1     Running            2          54d
kube-system     kube-apiserver-p006vm71                   1/1     Running            3          54d
kube-system     kube-controller-manager-p006vm71          1/1     Running            3          54d
kube-system     kube-proxy-gxp74                          1/1     Running            0          54d
kube-system     kube-scheduler-p006vm71                   1/1     Running            2          54d
kube-system     storage-provisioner                       0/1     ImagePullBackOff   0          46h
# kubectl describe pod instana-agent-v29bg -n instana-agent
Name:         instana-agent-v29bg
Namespace:    instana-agent
Priority:     0
Node:         <NODE_HOSTNAME>/<NODE_IP>
Start Time:   Thu, 02 Sep 2021 06:09:07 -0500
Labels:       app=instana-agent
              controller-revision-hash=5fb88695f5
              pod-template-generation=1
Annotations:  <none>
Status:       Running
IP:           <NODE_IP>
IPs:
  IP:           <NODE_IP>
Controlled By:  DaemonSet/instana-agent
Containers:
  instana-agent:
    Container ID:   docker://c070e3634db18d6fd746c18cd5fb9c7c0faa83276ad9eeca859b83ea747bef5c
    Image:          instana/agent
    Image ID:       docker-pullable://gcr.io/instana-agent-qa/instana-agent-docker@sha256:5ed7563896bf76fc4c52e2e16d3568a1043c8251d331571bbe6564904de46a76
    Port:           42699/TCP
    Host Port:      42699/TCP
    State:          Running
      Started:      Thu, 02 Sep 2021 06:09:09 -0500
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     1500m
      memory:  536870912
    Requests:
      cpu:     500m
      memory:  536870912
    Liveness:  http-get http://:42699/status delay=300s timeout=3s period=10s #success=1 #failure=3
    Environment:
      INSTANA_OPERATOR_MANAGED:         true
      INSTANA_AGENT_KEY:                <set to the key 'key' in secret 'instana-agent'>  Optional: false
      INSTANA_AGENT_POD_NAME:           instana-agent-v29bg (v1:metadata.name)
      POD_IP:                            (v1:status.podIP)
      INSTANA_ZONE:
      INSTANA_AGENT_ENDPOINT:           ingress-red-saas.instana.io
      INSTANA_AGENT_ENDPOINT_PORT:      443
      JAVA_OPTS:                        -Xmx170M -XX:+ExitOnOutOfMemoryError
      INSTANA_KUBERNETES_CLUSTER_NAME:  amit-minikube
      INSTANA_AGENT_TAGS:               example
    Mounts:
      /dev from dev (rw)
      /etc/machine-id from machine-id (rw)
      /root/configuration.yaml from configuration (rw,path="configuration.yaml")
      /run from run (rw)
      /sys from sys (rw)
      /var/data from var-data (rw)
      /var/lib from var-lib (rw)
      /var/log from log (rw)
      /var/run from var-run (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from instana-agent-token-j6stf (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  dev:
    Type:          HostPath (bare host directory volume)
    Path:          /dev
    HostPathType:
  run:
    Type:          HostPath (bare host directory volume)
    Path:          /run
    HostPathType:
  var-run:
    Type:          HostPath (bare host directory volume)
    Path:          /var/run
    HostPathType:
  sys:
    Type:          HostPath (bare host directory volume)
    Path:          /sys
    HostPathType:
  log:
    Type:          HostPath (bare host directory volume)
    Path:          /var/log
    HostPathType:
  var-lib:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib
    HostPathType:
  var-data:
    Type:          HostPath (bare host directory volume)
    Path:          /var/data
    HostPathType:
  machine-id:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/machine-id
    HostPathType:
  configuration:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      instana-agent
    Optional:  false
  instana-agent-token-j6stf:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  instana-agent-token-j6stf
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/disk-pressure:NoSchedule op=Exists
                 node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                 node.kubernetes.io/network-unavailable:NoSchedule op=Exists
                 node.kubernetes.io/not-ready:NoExecute op=Exists
                 node.kubernetes.io/pid-pressure:NoSchedule op=Exists
                 node.kubernetes.io/unreachable:NoExecute op=Exists
                 node.kubernetes.io/unschedulable:NoSchedule op=Exists
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  36s                      Successfully assigned instana-agent/instana-agent-v29bg to p006vm71
  Normal  Pulled     34s   kubelet, p006vm71  Container image "instana/agent" already present on machine
  Normal  Created    34s   kubelet, p006vm71  Created container instana-agent
  Normal  Started    34s   kubelet, p006vm71  Started container instana-agent
```
It can be seen that the image SHA from the pod description matches the one in [this job](https://ci.instana.io/teams/agent/pipelines/plinux-agent/jobs/ppc64le-build/builds/5) in the test build.

Note: I've reverted the top level commit that was added to avoid container.instana.io tagging and pushing for this dev branch and paused the pipeline.