### PR TITLE
Update instana-twistcli to latest available version 0.2.1

### DIFF
--- a/ci/prepare-instana-twistcli-inputs-task.yml
+++ b/ci/prepare-instana-twistcli-inputs-task.yml
@@ -26,4 +26,4 @@ run:
       mkdir -p instana-twistcli
       tar xfz instana-twistcli-build-artifacts/instana-twistcli-((instana-twistcli-version)).tar.gz -C instana-twistcli --strip-components=1
       cp instana-twistcli/scan-image.yml instana-twistcli-inputs
-      cp instana-agent-docker-git/.twistlockignore-amd64-static instana-twistcli-inputs
+      cp instana-agent-docker-git/.twistlockignore* instana-twistcli-inputs

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -10,7 +10,7 @@ var_sources:
     type: dummy
     config:
       vars:
-        instana-twistcli-version: '0.1.2'
+        instana-twistcli-version: '0.2.1'
 resource_types:
   - name: codebuild
     type: registry-image


### PR DESCRIPTION
# Why

We've released a new version of `instana-twistcli` that uses an updated version of `twistcli` under the hood: v21.08.514. The Twistlock service at twistlock.instana.io has also been recently updated to that same version. Though scans using an older version of `twistcli` will continue to work, we should update to keep them in sync.

# What

Update to use the latest available version of `instana-twistcli` v0.2.1

# References

- https://github.ibm.com/instana/instana-twistcli/blob/main/CHANGELOG.md
