### PR TITLE
Re enable image scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 download_key
+.idea/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 This repo contains the Dockerfiles relating to the various Instana agent containers.
 
 * [`dynamic`](./dynamic/) is the image used by default in the Helm chart and is suggested as the preferred image for a standard install; the `dynamic` image container a dynamic Instana agent, which is capable of updating itself automatically as new versions of its components are published.
-* [`static`](./static/) is an image that contains all run-time dependencies ideal for network access restricted environments such as airgapped servers.
+* [`static`](./static/) is an image that contains all run-time dependencies ideal for network access restricted environments such as air-gapped servers.
 
 For more information on dynamic and static agents, refer to the [Instana Host Agent Types](https://www.instana.com/docs/setup_and_manage/host_agent#host-agent-types) documentation.

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -780,24 +780,24 @@ jobs:
         vars:
           instana-twistcli-version: ((local-vars:instana-twistcli-version))
 
-      #- in_parallel:
-      #    steps:
-      #    - task: scan-image-amd64-static
-      #      privileged: true
-      #      file: instana-twistcli-inputs/scan-image.yml
-      #      vars:
-      #        target-image: gcr.io/instana-agent-qa/instana-agent-docker@((.:digest-amd64))
-      #        docker-json-key: ((project-berlin-tests-gcp-instana-qa))
-      #        ignorefile: instana-twistcli-inputs/.twistlockignore-amd64-static
-      #        min-vuln-severity: ''
-      #    - task: scan-image-amd64-j9-static
-      #      privileged: true
-      #      file: instana-twistcli-inputs/scan-image.yml
-      #     vars:
-      #        target-image: gcr.io/instana-agent-qa/instana-agent-docker@((.:digest-amd64-j9))
-      #        docker-json-key: ((project-berlin-tests-gcp-instana-qa))
-      #        ignorefile: instana-twistcli-inputs/.twistlockignore-amd64-static
-      #        min-vuln-severity: ''
+      - in_parallel:
+          steps:
+          - task: scan-image-amd64-static
+            privileged: true
+            file: instana-twistcli-inputs/scan-image.yml
+            vars:
+              target-image: gcr.io/instana-agent-qa/instana-agent-docker@((.:digest-amd64))
+              docker-json-key: ((project-berlin-tests-gcp-instana-qa))
+              ignorefile: instana-twistcli-inputs/.twistlockignore-amd64-static
+              min-vuln-severity: ''
+          - task: scan-image-amd64-j9-static
+            privileged: true
+            file: instana-twistcli-inputs/scan-image.yml
+            vars:
+              target-image: gcr.io/instana-agent-qa/instana-agent-docker@((.:digest-amd64-j9))
+              docker-json-key: ((project-berlin-tests-gcp-instana-qa))
+              ignorefile: instana-twistcli-inputs/.twistlockignore-amd64-static
+              min-vuln-severity: ''
 
   - name: verify-amd64-static
     max_in_flight: 1

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -10,7 +10,7 @@ var_sources:
     type: dummy
     config:
       vars:
-        instana-twistcli-version: '0.3.1'
+        instana-twistcli-version: '1.0.1'
 resource_types:
   - name: codebuild
     type: registry-image
@@ -779,7 +779,6 @@ jobs:
         file: instana-agent-docker-git/ci/prepare-instana-twistcli-inputs-task.yml
         vars:
           instana-twistcli-version: ((local-vars:instana-twistcli-version))
-
       - in_parallel:
           steps:
           - task: scan-image-amd64-static


### PR DESCRIPTION
Bump to version of `instana-twistcli` that actually scans images.

⚠️  Need to fix CVEs before merging this.