### PR TITLE
Update gomplate to 3.11.3 and golang to 1.18.6

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -13,7 +13,7 @@ RUN export GO_VERSION="1.18.6" && \
 	export GO_SHAR256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="4f26895921e52e0515b273659508802676aafa4765cc3751c383b27eb0e9dca1  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -9,7 +9,7 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:latest A
 
 ENV LANG=C.UTF-8
 
-RUN export GO_VERSION="1.17.9" && \
+RUN export GO_VERSION="1.18.x" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -13,7 +13,7 @@ RUN export GO_VERSION="1.17.9" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="f9a30d8e94b81eefbbe3455c21dc547ec0ebf0e010a809c72db617a4b37223a6  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -10,10 +10,10 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:latest A
 ENV LANG=C.UTF-8
 
 RUN export GO_VERSION="1.18.6" && \
-	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
+	export GO_SHAR256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -9,11 +9,11 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:latest A
 
 ENV LANG=C.UTF-8
 
-RUN export GO_VERSION="1.18.x" && \
+RUN export GO_VERSION="1.18.6" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=C.UTF-8
 RUN export GO_VERSION="1.17.9" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
-	export GOMPLATE_VERSION="3.10.0" && \
+	export GOMPLATE_VERSION="3.11.3" && \
 	export GOMPLATE_SHA256="f9a30d8e94b81eefbbe3455c21dc547ec0ebf0e010a809c72db617a4b37223a6  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -13,7 +13,7 @@ RUN export GO_VERSION="1.18.6" && \
 	export GO_SHAR256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="4f26895921e52e0515b273659508802676aafa4765cc3751c383b27eb0e9dca1  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -9,7 +9,7 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:latest A
 
 ENV LANG=C.UTF-8
 
-RUN export GO_VERSION="1.17.9" && \
+RUN export GO_VERSION="1.18.x" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -13,7 +13,7 @@ RUN export GO_VERSION="1.17.9" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="f9a30d8e94b81eefbbe3455c21dc547ec0ebf0e010a809c72db617a4b37223a6  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -10,10 +10,10 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:latest A
 ENV LANG=C.UTF-8
 
 RUN export GO_VERSION="1.18.6" && \
-	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
+	export GO_SHAR256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -9,11 +9,11 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:latest A
 
 ENV LANG=C.UTF-8
 
-RUN export GO_VERSION="1.18.x" && \
+RUN export GO_VERSION="1.18.6" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GOMPLATE_VERSION="3.11.3" && \
-	export GOMPLATE_SHA256="ab8b331b516cfc4bd075d042fb18ee4fa4d13058  v${GOMPLATE_VERSION}.tar.gz" && \
+	export GOMPLATE_SHA256="bb05f179a773fed60c6a454a24141aaa7e71edfd0f2d465ad610a3b8f1dc7fe8  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \
     wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=C.UTF-8
 RUN export GO_VERSION="1.17.9" && \
 	export GO_SHAR256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6 go${GO_VERSION}.linux-amd64.tar.gz" && \
 	export GO_BINARY="go${GO_VERSION}.linux-amd64.tar.gz" && \
-	export GOMPLATE_VERSION="3.10.0" && \
+	export GOMPLATE_VERSION="3.11.3" && \
 	export GOMPLATE_SHA256="f9a30d8e94b81eefbbe3455c21dc547ec0ebf0e010a809c72db617a4b37223a6  v${GOMPLATE_VERSION}.tar.gz" && \
     microdnf install tar gzip wget make findutils && \
     cd /tmp && \


### PR DESCRIPTION
The version of `gomplate` is updated to v3.11.3. 