### PR TITLE
Only distribute ctr for containerd

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -101,32 +101,28 @@ RUN export CONTAINERD_BASE_URL="https://github.com/containerd/containerd/release
        && curl -L --fail --show-error --silent "${CONTAINERD_BASE_URL}/download/v${CONTAINERD_VERSION}/${CONTAINERD_BINARY}" --output "${CONTAINERD_BINARY}" \
        && echo $(curl -L --fail --show-error --silent "${CONTAINERD_BASE_URL}/download/v${CONTAINERD_VERSION}/${CONTAINERD_BINARY}.sha256sum" | awk '{print $1}') "${CONTAINERD_BINARY}" | sha256sum --check \
        && gunzip "${CONTAINERD_BINARY}" \
-       && tar xf "${CONTAINERD_BINARY//.gz/}" \
+       && tar xf "${CONTAINERD_BINARY//.gz/}" bin/ctr \
        && mv bin/* /usr/local/bin \
        && rm -rf /tmp/* \
 )
 
-# On s390x, install docker ce and containerd from docker static s390x build
+# On s390x, install docker ce from docker static s390x build
 RUN [[ "${TARGETPLATFORM}" != 'linux/s390x' ]] || ( \
         cd /tmp \
         && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
         && gunzip docker-18.06.3-ce.tgz \
         && tar -xvf docker-18.06.3-ce.tar \
         && mv docker/docker /usr/local/bin/docker \
-        && mv docker/docker-containerd /usr/local/bin/containerd \
-        && mv docker/docker-containerd-shim /usr/local/bin/containerd-shim \
         && rm -rf /tmp/* \
     )
 
-# On ppc64le, install docker ce and containerd from docker static ppc64le build
+# On ppc64le, install docker ce from docker static ppc64le build
 RUN [[ "${TARGETPLATFORM}" != 'linux/ppc64le' ]] || ( \
         cd /tmp \
         && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/ppc64le/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
         && gunzip docker-18.06.3-ce.tgz \
         && tar -xvf docker-18.06.3-ce.tar \
         && mv docker/docker /usr/local/bin/docker \
-        && mv docker/docker-containerd /usr/local/bin/containerd \
-        && mv docker/docker-containerd-shim /usr/local/bin/containerd-shim \
         && rm -rf /tmp/* \
     )
 

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -102,32 +102,28 @@ RUN export CONTAINERD_BASE_URL="https://github.com/containerd/containerd/release
        && curl -L --fail --show-error --silent "${CONTAINERD_BASE_URL}/download/v${CONTAINERD_VERSION}/${CONTAINERD_BINARY}" --output "${CONTAINERD_BINARY}" \
        && echo $(curl -L --fail --show-error --silent "${CONTAINERD_BASE_URL}/download/v${CONTAINERD_VERSION}/${CONTAINERD_BINARY}.sha256sum" | awk '{print $1}') "${CONTAINERD_BINARY}" | sha256sum --check \
        && gunzip "${CONTAINERD_BINARY}" \
-       && tar xf "${CONTAINERD_BINARY//.gz/}" \
+       && tar xf "${CONTAINERD_BINARY//.gz/}" bin/ctr \
        && mv bin/* /usr/local/bin \
        && rm -rf /tmp/* \
 )
 
-# On s390x install docker ce and containerd from docker static s390x build
+# On s390x install docker ce from docker static s390x build
 RUN [[ "${TARGETPLATFORM}" != 'linux/s390x' ]] || ( \
         cd /tmp \
         && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/s390x/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
         && gunzip docker-18.06.3-ce.tgz \
         && tar -xvf docker-18.06.3-ce.tar \
         && mv docker/docker /usr/local/bin/docker \
-        && mv docker/docker-containerd /usr/local/bin/containerd \
-        && mv docker/docker-containerd-shim /usr/local/bin/containerd-shim \
         && rm -rf /tmp/* \
     )
 
-# On ppc64le, install docker ce and containerd from docker static ppc64le build
+# On ppc64le, install docker ce from docker static ppc64le build
 RUN [[ "${TARGETPLATFORM}" != 'linux/ppc64le' ]] || ( \
         cd /tmp \
         && curl -L --fail --show-error --silent https://download.docker.com/linux/static/stable/ppc64le/docker-18.06.3-ce.tgz -o /tmp/docker-18.06.3-ce.tgz \
         && gunzip docker-18.06.3-ce.tgz \
         && tar -xvf docker-18.06.3-ce.tar \
         && mv docker/docker /usr/local/bin/docker \
-        && mv docker/docker-containerd /usr/local/bin/containerd \
-        && mv docker/docker-containerd-shim /usr/local/bin/containerd-shim \
         && rm -rf /tmp/* \
     )
 


### PR DESCRIPTION
We don't need to distribute `containerd` which leads to additional CVEs in our container.
By only extracting **ctr**, we can get rid of the CVEs.