### PR TITLE
Fix ctr version to v1.6.19

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -95,9 +95,11 @@ RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' || "${TARGETPLATFORM}" = 'linux/ppc64
     )
 
 # containerd cli is only available for amd64
+# We are fixing the ctr version to v1.6.19 to avoid breaking changes in the future.
+# Fetching the latest version can be done: $(curl -w '\n' -L -s -H 'Accept: application/json' "${CONTAINERD_BASE_URL}/latest" | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/')
 RUN export CONTAINERD_BASE_URL="https://github.com/containerd/containerd/releases" \
     && [[ "${TARGETPLATFORM}" != 'linux/amd64' ]] || ( \
-       export CONTAINERD_VERSION=$(curl -w '\n' -L -s -H 'Accept: application/json' "${CONTAINERD_BASE_URL}/latest" | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/') \
+       export CONTAINERD_VERSION="1.6.19" \
        && export CONTAINERD_BINARY="containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz" \
        && echo "Containerd version: ${CONTAINERD_VERSION}" \
        && cd /tmp \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -96,9 +96,11 @@ RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' || "${TARGETPLATFORM}" = 'linux/ppc64
     )
 
 # containerd cli is only available for amd64
+# We are fixing the ctr version to v1.6.19 to avoid breaking changes in the future.
+# Fetching the latest version can be done: $(curl -w '\n' -L -s -H 'Accept: application/json' "${CONTAINERD_BASE_URL}/latest" | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/')
 RUN export CONTAINERD_BASE_URL="https://github.com/containerd/containerd/releases" \
     && [[ "${TARGETPLATFORM}" != 'linux/amd64' ]] || ( \
-       export CONTAINERD_VERSION=$(curl -w '\n' -L -s -H 'Accept: application/json' "${CONTAINERD_BASE_URL}/latest" | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/') \
+       export CONTAINERD_VERSION="1.6.19" \
        && export CONTAINERD_BINARY="containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz" \
        && echo "Containerd version: ${CONTAINERD_VERSION}" \
        && cd /tmp \


### PR DESCRIPTION
The new version of the `ctr` CLI (v1.7.0) fails to get back metrics for containers when `cgroupv1` is in use.

The following error is printed:
```
ctr --address "/run/containerd/containerd.sock" --namespace k8s.io tasks metric 0ca356b7055f70f7f5096d5df87f937e96d50573d099bb727d32b5785959e37c --format json
ctr: cannot convert metric data to cgroups.Metrics or windows.Statistics
```

With the proposed solution we are anchoring the version of the `ctr` CLI to `v1.6.19`.