### PR TITLE
update links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This repo contains the Dockerfiles relating to the various Instana agent contain
 * [`dynamic`](./dynamic/) is the image used by default in the Helm chart and is suggested as the preferred image for a standard install; the `dynamic` image container a dynamic Instana agent, which is capable of updating itself automatically as new versions of its components are published.
 * [`static`](./static/) is an image that contains all run-time dependencies ideal for network access restricted environments such as air-gapped servers.
 
-For more information on dynamic and static agents, refer to the [Instana Host Agent Types](https://www.instana.com/docs/setup_and_manage/host_agent#host-agent-types) documentation.
+For more information on dynamic and static agents, refer to the [Instana Host Agent Types](https://www.ibm.com/docs/en/instana-observability/current?topic=agents-host#host-agent-types) documentation.

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -6,7 +6,7 @@ It may require proxy settings for egress access to:
 * the `${INSTANA_AGENT_ENDPOINT}`, which may either be for your self-hosted Instana installation or for the Instana SaaS
 * the [Instana Artifactory repository](https://artifact-public.instana.io/), unless you set up a mirror and use the `INSTANA_MVN_REPOSITORY_URL` to direct the Instana Agent to use it
 
-Additional documentation about the usage of this image is available on the [Installing the Host Agent on Docker](https://www.instana.com/docs/setup_and_manage/host_agent/on/docker) documentation.
+Additional documentation about the usage of this image is available on the [Installing the Host Agent on Docker](https://www.ibm.com/docs/en/instana-observability/current?topic=agents-installing-host-agent-docker) documentation.
 
 ## Building
 

--- a/dynamic/help.1
+++ b/dynamic/help.1
@@ -2,7 +2,7 @@
 .PP
 This is the official Docker dynamic image of the Instana Agent.
 
-\[la]https://www.instana.com\[ra]
+\[la]https://www.ibm.com/products/instana\[ra]
 
 .SH Installation
 .PP
@@ -76,5 +76,5 @@ After the agent tarball was unpacked, the (eventually mounted) files are being p
 
 .SH Documentation
 .PP
-Agent and general documentation is available at 
-\[la]https://docs.instana.com\[ra]
+Agent and general documentation is available at
+\[la]https://www.ibm.com/docs/en/instana-observability/current\[ra]

--- a/static/help.1
+++ b/static/help.1
@@ -2,7 +2,7 @@
 .PP
 This is the official Docker static image of the Instana Agent
 
-\[la]https://www.instana.com\[ra]
+\[la]https://www.ibm.com/products/instana\[ra]
 
 .SH Installation
 .PP
@@ -76,5 +76,5 @@ After the agent tarball was unpacked, the (eventually mounted) files are being p
 
 .SH Documentation
 .PP
-Agent and general documentation is available at 
-\[la]https://docs.instana.com\[ra]
+Agent and general documentation is available at
+\[la]https://www.ibm.com/docs/en/instana-observability/current\[ra]


### PR DESCRIPTION
This was mainly motivated because this is one of the few repositories that still linked to docs.instana.com (which has been a redirect to instana.com/docs for a couple of years now).

While I was at it, I also replaced the other remaining instana.com links with the appropriate ibm.com links (because instana.com is defunct now as well).