### PR TITLE
Remove libseccomp from Agent Container

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -73,7 +73,7 @@ LABEL name="instana-agent" \
 ARG TARGETPLATFORM='linux/amd64'
 
 RUN microdnf upgrade \
-    && microdnf install --nodocs --noplugins hostname procps iproute util-linux python3 jq findutils less tar gzip socat libseccomp \
+    && microdnf install --nodocs --noplugins hostname procps iproute util-linux python3 jq findutils less tar gzip socat \
     && cd /tmp/ \
     && microdnf download runc \
     && rpm -i runc*.rpm --nodeps \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -74,7 +74,7 @@ LABEL name="instana-agent" \
 ARG TARGETPLATFORM='linux/amd64'
 
 RUN microdnf upgrade \
-    && microdnf install --nodocs --noplugins hostname procps iproute util-linux python3 jq findutils less tar gzip socat libseccomp \
+    && microdnf install --nodocs --noplugins hostname procps iproute util-linux python3 jq findutils less tar gzip socat \
     && cd /tmp/ \
     && microdnf download runc \
     && rpm -i runc*.rpm --nodeps \


### PR DESCRIPTION
We know that this can potentially cause problems and we should not provide our own version of it and rather use what is present on the host.