### PR TITLE
ci: Replace docker build args with secret mounts

### DIFF
--- a/ci/container-image-build-task.yml
+++ b/ci/container-image-build-task.yml
@@ -24,7 +24,7 @@ params:
   CONTEXT: source/((flavor))
   IMAGE_PLATFORM: ((target-platform)) # This param tells the `concourse-oci-build-task` task which architecture to build the image for.
   BUILD_ARG_TARGETPLATFORM: ((target-platform)) # the instana-agent-docker Dockerfile requires a TARGETPLATFORM build arg.
-  BUILD_ARG_DOWNLOAD_KEY: ((agent-download-key)) # required by the instana-agent-docker Dockerfile
+  BUILDKIT_SECRETTEXT_DOWNLOAD_KEY: ((agent-download-key)) # required by the instana-agent-docker Dockerfile
   BUILD_ARG_FLAVOR: ((flavor)) # required by the instana-agent-docker Dockerfile
   BUILD_ARG_CLASSIFIER: ((classifier)) # required by the instana-agent-docker Dockerfile
   BUILD_ARG_VERSION: ((version)) # required by the instana-agent-docker Dockerfile

--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -46,11 +46,11 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS instana-agent
 
 ARG TARGETPLATFORM='linux/amd64'
 ARG CLASSIFIER=''
-ARG DOWNLOAD_KEY
 # This is for backwards compatibility for end users that build their own images
 ARG FTP_PROXY
 
-RUN microdnf update && curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
+RUN --mount=type=secret,id=DOWNLOAD_KEY DOWNLOAD_KEY="$(cat /run/secrets/DOWNLOAD_KEY)" && \
+    microdnf update && curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     rpm --import /tmp/Instana.gpg && \
     export arch=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'x86_64' ;; 'linux/arm64') echo 'aarch64' ;; 'linux/s390x') echo 's390x' ;; 'linux/ppc64le') echo 'ppc64le' ;; esac) && \
     [[ -z "${FTP_PROXY}" ]] || DOWNLOAD_KEY="${FTP_PROXY}" && \

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -18,12 +18,16 @@ features](https://github.com/docker/cli/blob/master/experimental/README.md) need
 export TARGETPLATFORM=linux/s390x
 export DOWNLOAD_KEY=my-key
 
+echo "${DOWNLOAD_KEY}" > ${HOME}/.INSTANA_DOWNLOAD_KEY
+
 docker buildx build --no-cache \
-  --build-arg DOWNLOAD_KEY="${DOWNLOAD_KEY}" \
+  --secret id=DOWNLOAD_KEY,src=${HOME}/.INSTANA_DOWNLOAD_KEY \
   --platform="${TARGETPLATFORM}" \
   --build-arg "TARGETPLATFORM=${TARGETPLATFORM}" \
   -t instana/agent \
   .
+
+rm -f ${HOME}/.INSTANA_DOWNLOAD_KEY
 ```
 
 Supported values of `<PLATFORM>`:

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -46,11 +46,12 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS instana-agent
 
 ARG TARGETPLATFORM='linux/amd64'
 ARG CLASSIFIER=''
-ARG DOWNLOAD_KEY
 # This is for backwards compatibility for end users that build their own images
 ARG FTP_PROXY
 
-RUN microdnf update && curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
+# Use secret mounts to prevent leakage of secrets in docker image metadata
+RUN --mount=type=secret,id=DOWNLOAD_KEY DOWNLOAD_KEY="$(cat /run/secrets/DOWNLOAD_KEY)" && \
+    microdnf update && curl -sSL https://packages.instana.io/Instana.gpg -o /tmp/Instana.gpg && \
     rpm --import /tmp/Instana.gpg && \
     export arch=$(case "${TARGETPLATFORM}" in 'linux/amd64') echo 'x86_64' ;; 'linux/arm64') echo 'aarch64' ;; 'linux/s390x') echo 's390x' ;; 'linux/ppc64le') echo 'ppc64le' ;; esac) && \
     [[ -z "${FTP_PROXY}" ]] || DOWNLOAD_KEY="${FTP_PROXY}" && \

--- a/static/README.md
+++ b/static/README.md
@@ -12,12 +12,16 @@ features](https://github.com/docker/cli/blob/master/experimental/README.md) need
 export TARGETPLATFORM=linux/s390x
 export DOWNLOAD_KEY=my-key
 
+echo "${DOWNLOAD_KEY}" > ${HOME}/.INSTANA_DOWNLOAD_KEY
+
 docker buildx build --no-cache \
-  --build-arg DOWNLOAD_KEY="${DOWNLOAD_KEY}" \
+  --secret id=DOWNLOAD_KEY,src=${HOME}/.INSTANA_DOWNLOAD_KEY \
   --platform="${TARGETPLATFORM}" \
   --build-arg "TARGETPLATFORM=${TARGETPLATFORM}" \
   -t containers.instana.io/instana/release/agent/static \
   .
+
+rm -f ~/.INSTANA_DOWNLOAD_KEY
 ```
 
 Supported values of `<PLATFORM>`:


### PR DESCRIPTION
While analyzing the docker build process, I noticed a potential risky transfer of secrets in the docker build process.

```
docker buildx build --no-cache \
  --build-arg DOWNLOAD_KEY="${DOWNLOAD_KEY}" \
  --platform="${TARGETPLATFORM}" \
  --build-arg "TARGETPLATFORM=${TARGETPLATFORM}" \
  -t containers.instana.io/instana/release/agent/static \
  .
```

The build-args of a docker build are persisted in the docker image history.
As of now, this is not a problem, as the mentioned image is using a multi-staged build and only the last image (parts after the last FROM statement) are persisted. But, if statements in the Dockerfile are rearranged or the DOWNLOAD_KEY variable is used somewhere in the last stage, it could be present in the docker image metadata and everyone could fetch them via checking the docker history output.

This was a common problem in lots of projects, but buildkit implemented a solution for that problem.
Instead of using build-args, buildkit offers dedicated secret mounts which we should incorporate instead.

https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypesecret

I propose to switch to the secret mounts to avoid potential risks going forward, it should be implemented in the concourse since v0.10.0 (https://github.com/concourse/oci-build-task/pull/88).