### PR TITLE
Ignore CVE-2023-39323

### DIFF
--- a/.twistlockignore-amd64-static
+++ b/.twistlockignore-amd64-static
@@ -4,3 +4,4 @@ CVE-2023-24540 # we do not do any whitespace cleaning
 CVE-2023-29402 # we are not in control of the building pipeline for external components
 CVE-2023-29404 # we are not in control of the building pipeline for external components
 CVE-2023-29405 # we are not in control of the building pipeline for external components
+CVE-2023-39323 # we are not in control of the building pipeline for external components


### PR DESCRIPTION
As we don't control the build pipeline for the GO artifacts, we need to exclude the CVE.