### PR TITLE
chore(deps): Update ctr to 1.6.26

### DIFF
--- a/dynamic/Dockerfile
+++ b/dynamic/Dockerfile
@@ -94,10 +94,10 @@ RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' || "${TARGETPLATFORM}" = 'linux/ppc64
         && microdnf clean all \
     )
 
-# We are fixing the ctr version to v1.6.25 to avoid breaking changes in the future.
+# We are fixing the ctr version to v1.6.26 to avoid breaking changes in the future.
 # Fetching the latest version can be done: $(curl -w '\n' -L -s -H 'Accept: application/json' "${CONTAINERD_BASE_URL}/latest" | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/')
 RUN [[ "${TARGETPLATFORM}" != 'linux/amd64' && "${TARGETPLATFORM}" != 'linux/ppc64le' && "${TARGETPLATFORM}" != 'linux/arm64' ]] || ( \
-   export CONTAINERD_VERSION="1.6.25" \
+   export CONTAINERD_VERSION="1.6.26" \
    && export ARCH=${TARGETPLATFORM//\//-} \
    && export CONTAINERD_BASE_URL="https://github.com/containerd/containerd/releases" \
    && export CONTAINERD_BINARY="containerd-${CONTAINERD_VERSION}-${ARCH}.tar.gz" \

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -96,10 +96,10 @@ RUN [[ "${TARGETPLATFORM}" = 'linux/s390x' || "${TARGETPLATFORM}" = 'linux/ppc64
         && microdnf clean all \
     )
 
-# We are fixing the ctr version to v1.6.25 to avoid breaking changes in the future.
+# We are fixing the ctr version to v1.6.26 to avoid breaking changes in the future.
 # Fetching the latest version can be done: $(curl -w '\n' -L -s -H 'Accept: application/json' "${CONTAINERD_BASE_URL}/latest" | sed -e 's/.*"tag_name":"v\([0-9\.]*\)".*/\1/')
 RUN [[ "${TARGETPLATFORM}" != 'linux/amd64' && "${TARGETPLATFORM}" != 'linux/ppc64le' && "${TARGETPLATFORM}" != 'linux/arm64' ]] || ( \
-   export CONTAINERD_VERSION="1.6.25" \
+   export CONTAINERD_VERSION="1.6.26" \
    && export ARCH=${TARGETPLATFORM//\//-} \
    && export CONTAINERD_BASE_URL="https://github.com/containerd/containerd/releases" \
    && export CONTAINERD_BINARY="containerd-${CONTAINERD_VERSION}-${ARCH}.tar.gz" \


### PR DESCRIPTION
Fixes GHSA-m425-mq94-257g in containerd:
```json
{
  "cve": "GHSA-m425-mq94-257g",
  "severity": "high",
  "status": "fixed in 1.58.3, 1.57.1, 1.56.3",
  "packagePath": "/usr/local/bin/ctr",
  "packageName": "google.golang.org/grpc",
  "packageVersion": "v1.50.1",
  "link": "https://github.com/advisories/GHSA-m425-mq94-257g"
}
```